### PR TITLE
Test for binary rebuilding of a number from constituent bits.

### DIFF
--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -1144,7 +1144,7 @@ class std::numeric_limits<boost::multiprecision::backends::cpp_double_float<Floa
  public:
    static constexpr bool is_iec559 = false;
 
-   static constexpr int digits       = 2 * std::numeric_limits<FloatingPointType>::digits - 2;
+   static constexpr int digits       = 2 * std::numeric_limits<FloatingPointType>::digits - 2;// - 2; without -2 ?
    static constexpr int digits10     = 2 * std::numeric_limits<FloatingPointType>::digits10 - 1;
    static constexpr int max_digits10 = 2 * std::numeric_limits<FloatingPointType>::max_digits10;
 

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -1144,9 +1144,9 @@ class std::numeric_limits<boost::multiprecision::backends::cpp_double_float<Floa
  public:
    static constexpr bool is_iec559 = false;
 
-   static constexpr int digits       = 2 * std::numeric_limits<FloatingPointType>::digits - 2;// - 2; without -2 ?
-   static constexpr int digits10     = 2 * std::numeric_limits<FloatingPointType>::digits10 - 1;
-   static constexpr int max_digits10 = 2 * std::numeric_limits<FloatingPointType>::max_digits10;
+   static constexpr int digits       = 2 * std::numeric_limits<FloatingPointType>::digits - 2;
+   static constexpr int digits10     =  int(float(digits - 1) * 0.301F);
+   static constexpr int max_digits10 =  int(float(digits)     * 0.301F) + 2;
 
    static constexpr int max_exponent = std::numeric_limits<FloatingPointType>::max_exponent - std::numeric_limits<FloatingPointType>::digits;
    static constexpr int min_exponent = std::numeric_limits<FloatingPointType>::min_exponent + std::numeric_limits<FloatingPointType>::digits;

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -220,7 +220,7 @@ cpp_double_float<FloatingPointType>::fast_exact_sum(const float_type& a, const f
 {
    using std::fabs;
    using std::isnormal;
-   BOOST_ASSERT(fabs(a) >= fabs(b) || a == 0.0 || !isnormal(a));
+   //BOOST_ASSERT(fabs(a) >= fabs(b) || a == 0.0 || !isnormal(a));
 
    std::pair<float_type, float_type> out;
    out.first  = a + b;

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -880,22 +880,22 @@ operator<<(std::basic_ostream<char_type, traits_type>& os, const cpp_double_floa
       return os;
    }
 
-  if (f < FloatingPointType(0) || os.flags() & std::ios::showpos)
-      os << (f < FloatingPointType(0) ? "-" : "+");
+  if (f < cpp_double_float<FloatingPointType>(0) || os.flags() & std::ios::showpos)
+      os << (f < cpp_double_float<FloatingPointType>(0) ? "-" : "+");
 
    int exp10 = 0;
 
-   if (f != FloatingPointType(0))
+   if (f != cpp_double_float<FloatingPointType>(0))
       exp10 = (int)floor(log10(fabs(f.first())));
    else
       exp10 = 0;
 
-   auto f_prime = (f > FloatingPointType(0) ? f : -f);
+   auto f_prime = (f > cpp_double_float<FloatingPointType>(0) ? f : -f);
    f_prime /= cpp_double_float<FloatingPointType>::pow10(exp10);
    
    // TODO Handle subnormal numbers
 
-   if (f_prime < FloatingPointType(1) && f_prime > FloatingPointType(0))
+   if (f_prime < cpp_double_float<FloatingPointType>(1) && f_prime > cpp_double_float<FloatingPointType>(0))
    {
       f_prime *= FloatingPointType(10);
       exp10++;

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -102,7 +102,7 @@ ConstructionType construct_from(FloatingPointType f)
 }
 
 template <typename FloatingPointType>
-int test_op(char op, const unsigned count = 0x10000U)
+bool test_op(char op, const unsigned count = 0x10000U)
 {
    using naked_double_float_type = FloatingPointType;
    using control_float_type      = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<std::numeric_limits<naked_double_float_type>::digits10 * 2 + 1>, boost::multiprecision::et_off>;
@@ -142,7 +142,7 @@ int test_op(char op, const unsigned count = 0x10000U)
          break;
       default:
          std::cerr << " internal error (unknown operator: " << op << ")" << std::endl;
-         return -1;
+         return false;
       }
 
       // if exponent of result is out of range, continue
@@ -166,12 +166,13 @@ int test_op(char op, const unsigned count = 0x10000U)
          //std::cerr << "actual  : " << ctrl_df_c << " (" << df_c.get_raw_str() << ")" << std::endl;
          //std::cerr << "error   : " << delta << std::endl;
 
-         return -1;
+         return false;
       }
    }
 
   std::cout << " ok [" << count << " tests passed]" << std::endl;
-  return 0;
+
+  return true;
 }
 
 template <typename T>
@@ -179,19 +180,19 @@ bool test_arithmetic()
 {
    std::cout << "Testing correctness of arithmetic operators for " << boost::core::demangle(typeid(T).name()) << std::endl;
 
-   int e = 0;
-   e += test_op<T>('+');
-   e += test_op<T>('-');
-   e += test_op<T>('*');
-   e += test_op<T>('/');
+   bool result_is_ok = true;
+
+   result_is_ok &= test_op<T>('+');
+   result_is_ok &= test_op<T>('-');
+   result_is_ok &= test_op<T>('*');
+   result_is_ok &= test_op<T>('/');
 
    std::cout << std::endl;
 
-   return e;
+   return result_is_ok;
 }
 
 } // namespace test_arithmetic_cpp_double_float
-
 
 int main()
 {

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -8,7 +8,8 @@
 //
 // Test for correctness of arithmetic operators of cpp_double_float<>
 
-
+// cd /mnt/c/Users/User/Documents/Ks/PC_Software/Test
+// g++ -Wall -march=native -std=c++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 test.cpp -o test_double_float.exe
 
 #include <boost/config.hpp>
 #include <boost/multiprecision/cpp_double_float.hpp>

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -152,7 +152,7 @@ int test_op(char op, const unsigned count = 10000U)
       if (delta > MaxError)
       {
          std::cerr << std::setprecision(std::numeric_limits<naked_double_float_type>::digits10 + 2);
-         std::cerr << " [FAILED] while performing '" << ctrl_a << "' " << op << " '" << ctrl_b << "'" << std::endl;
+         std::cerr << " [FAILED] while performing '" << std::setprecision(100000) << ctrl_a << "' " << op << " '" << ctrl_b << "', got incorrect result: " << (df_c) << std::endl;
 
          // uncomment for more debugging information (only for cpp_double_float<> type)
          //std::cerr << "(df_a = " << df_a.get_raw_str() << ", df_b = " << df_b.get_raw_str() << ")" << std::endl;

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -9,7 +9,7 @@
 // Test for correctness of arithmetic operators of cpp_double_float<>
 
 // cd /mnt/c/Users/User/Documents/Ks/PC_Software/Test
-// g++ -Wall -march=native -std=c++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 test.cpp -o test_double_float.exe
+// g++ -O3 -Wall -march=native -std=c++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 test.cpp -o test_double_float.exe
 
 #include <boost/config.hpp>
 #include <boost/multiprecision/cpp_double_float.hpp>
@@ -102,7 +102,7 @@ ConstructionType construct_from(FloatingPointType f)
 }
 
 template <typename FloatingPointType>
-int test_op(char op, const unsigned count = 1000000U)
+int test_op(char op, const unsigned count = 0x10000U)
 {
    using naked_double_float_type = FloatingPointType;
    using control_float_type      = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<std::numeric_limits<naked_double_float_type>::digits10 * 2 + 1>, boost::multiprecision::et_off>;

--- a/test/test_cpp_double_float_constructors.cpp
+++ b/test/test_cpp_double_float_constructors.cpp
@@ -8,7 +8,8 @@
 //
 // Constructor tests for cpp_double_float<>
 
-
+// cd /mnt/c/Users/User/Documents/Ks/PC_Software/Test
+// g++ -O3 -Wall -march=native -std=c++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 test.cpp -o test_double_float.exe
 
 #include <boost/config.hpp>
 #include <boost/multiprecision/cpp_double_float.hpp>

--- a/test/test_cpp_double_float_constructors.cpp
+++ b/test/test_cpp_double_float_constructors.cpp
@@ -37,13 +37,12 @@ constexpr T max(T a, T b)
 
 // FIXME: this looks like a duplicate from test_cpp_double_float_comparision.cpp file.
 template<typename FloatingPointType> struct is_floating_point {
-static const bool value;
-};
-template<typename FloatingPointType> const bool is_floating_point<FloatingPointType>::value = std::is_floating_point<FloatingPointType>::value
+   static constexpr bool value = std::is_floating_point<FloatingPointType>::value
 #ifdef BOOST_MATH_USE_FLOAT128
-or std::is_same<FloatingPointType,boost::multiprecision::float128>::value
+                                 or std::is_same<FloatingPointType, boost::multiprecision::float128>::value
 #endif
-;
+       ;
+};
 
 template <typename FloatingPointType,
           typename std::enable_if<is_floating_point<FloatingPointType>::value, bool>::type = true>
@@ -70,7 +69,7 @@ NumericType uniform_integral_number()
 
 
 template <typename NumericType,
-          typename std::enable_if<std::is_integral<NumericType>::value && !is_floating_point<NumericType>::value, bool>::type = true>
+          typename std::enable_if<std::is_integral<NumericType>::value, bool>::type = true>
 NumericType get_rand()
 {
    return uniform_integral_number<NumericType>();

--- a/test/test_cpp_double_float_decomposition.cpp
+++ b/test/test_cpp_double_float_decomposition.cpp
@@ -1,0 +1,177 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2021 Fahad Syed.
+//  Copyright 2021 Christopher Kormanyos.
+//  Copyright 2021 Janek Kozicki.
+//  Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Test for binary rebuilding of a number from constituent bits.
+
+
+#include <boost/config.hpp>
+#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#ifdef BOOST_MATH_USE_FLOAT128
+#include <boost/multiprecision/float128.hpp>
+#endif
+#include <boost/core/demangle.hpp>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace boost { namespace multiprecision {
+namespace backends {
+template <typename T> int sign(T val) { return (T(0) < val) - (val < T(0)); }
+
+// FIXME: very rudimentary pow implementation.
+template <typename Rr>
+inline cpp_double_float<Rr> pow(const cpp_double_float<Rr>& a, int exp)
+{
+	cpp_double_float<Rr> ret{1};
+	bool positive = true;
+	if(exp < 0 ) {
+		exp      = -exp;
+		positive = false;
+	}
+	if(exp == 0)
+		return 1;
+	if(a == 0)
+		return 0;
+	while(exp-- > 0) {
+		ret*= a;
+	}
+	return positive ? ret : cpp_double_float<Rr>(1)/ret;
+}
+
+// FIXME: very rudimentary frexp implementation.
+template <typename Rr, typename Exp>
+inline cpp_double_float<Rr> frexp(const cpp_double_float<Rr>& a, Exp* b)
+{
+	using std::frexp;
+	using std::pow;
+	Exp c=0;
+	Rr second = frexp(a.crep().second, &c);
+	Rr first  = frexp(a.crep().first , b);
+	auto ret = cpp_double_float<Rr>(std::make_pair(first, second * pow(Rr(2.0), c - *b )));
+//std::cout << "frexp ret = " << std::setprecision(10000) << ret << " exponent = " << *b << std::endl;
+	BOOST_ASSERT((ret >= 0.5) or (ret <= -0.5) or ((ret == 0) and (*b == 0)));
+	BOOST_ASSERT((ret <  1  ) or (ret >  -1  ) or ((ret == 0) and (*b == 0)));
+	return ret;
+}
+
+class DecomposedReal {
+private:
+	int                        sig;
+	int                        exp;
+	std::vector<unsigned char> bits;
+
+public:
+	template <typename Rr> DecomposedReal(Rr x)
+	{
+		int ex   = 0;
+		Rr  norm = frexp(x > 0 ? x : -x, &ex);
+		sig      = sign(x);
+		exp      = ex - 1;
+		ex       = 0;
+		int pos  = 0;
+		bits.resize(std::numeric_limits<Rr>::digits, 0);
+		while (
+			norm != 0                  // correct condition
+		//	pos-ex < int(bits.size())  //
+		) {
+			pos -= ex;
+/*
+std::cout << "norm        = " << norm        << ", ";
+std::cout << "ex          = " << ex          << ", ";
+std::cout << "pos         = " << pos         << ", ";
+std::cout << "bits.size() = " << bits.size() << std::endl;
+*/
+			BOOST_ASSERT((ex <= 0) and (pos < int(bits.size())) and (pos >= 0));
+			bits[pos] = 1;
+			norm -= static_cast<Rr>(0.5);
+			norm = frexp(norm, &ex);
+		};
+	}
+	template <typename Rr> Rr rebuild()
+	{
+		Rr  ret = 0;
+		int i   = 0;
+		for (auto c : bits) {
+			if (c != 0) {
+				ret += pow(static_cast<Rr>(2), static_cast<Rr>(exp - i));
+			}
+			++i;
+		}
+		return ret * static_cast<Rr>(sig);
+	}
+	template <typename Rr = double> void print()
+	{
+		std::cout << "sign : " << sig << std::endl;
+		std::cout << "exp  : " << exp << std::endl;
+		std::cout << "bits : ";
+		for (auto c : bits)
+			std::cout << int(c);
+		std::cout << "\nreconstructed number: " << rebuild<Rr>() << "\n\n";
+	}
+};
+
+template <typename Rr> void print_number(const Rr& arg)
+{
+	std::cout << std::setprecision(std::numeric_limits<Rr>::digits10 + 3);
+	std::cout << "original number     = " << std::setprecision(100000) << arg << std::endl;
+	DecomposedReal d(arg);
+	d.print<Rr>();
+	std::cout << "arg             = " << arg << std::endl;
+	std::cout << "d.rebuild<Rr>() = " << d.rebuild<Rr>() << std::endl;
+	BOOST_ASSERT(arg == d.rebuild<Rr>());
+};
+}}}
+//////////////////////////////
+
+template<typename R>
+void try_number(std::string str) {
+   std::cout << std::setprecision(100000);
+   std::cout << "\n\nTesting number : " << str << std::endl;
+   auto z=boost::multiprecision::backends::cpp_double_float<R>(0);
+   std::cout << "With type " << boost::core::demangle(typeid(decltype(z)).name()) << std::endl;
+
+   z.set_str(str);
+
+   int  ex = 0;
+   auto z2 = frexp(z,&ex);
+   std::cout << "exponent = " << ex << std::endl;
+   std::cout << "number   = " << z2 << std::endl;
+   std::cout << "trying to rebuild the number:\n";
+   print_number(z);
+   print_number(z2);
+}
+
+template<typename R>
+void test() {
+// binary representation of this number:
+//                11111111100011011111111110001100000011111111111111111000111000001111111111110000000000011111111110000000001111111110000001111 * 2^1407
+   try_number<R>("7.07095004791213209137407618364459278413421454874042247410492385622373956879713960311588804604245728321440648803023224236513586176837484939909893244653903501e+423");
+// binary representation of this number:
+//                11111111100011011111111110001100000011111111111111111000111000001111111111110000000000011111111110000000001111111110000001111 * 2^65
+   try_number<R>("73658621713667056515.99902391387240466018304640982705677743069827556610107421875");
+}
+
+int main()
+{
+
+//test<float>();
+//test<double>();
+  test<long double>();
+//test<boost::multiprecision::float128>();
+
+/*
+   auto z=boost::multiprecision::backends::cpp_double_float<long double>(0);
+   z.set_str("5.0395749966458598419365441242084052981209828021829231181382593274122924204e+423");
+   print_number(z);
+*/
+}
+

--- a/test/test_cpp_double_float_decomposition.cpp
+++ b/test/test_cpp_double_float_decomposition.cpp
@@ -89,6 +89,9 @@ std::cout << "norm        = " << norm        << ", ";
 std::cout << "ex          = " << ex          << ", ";
 std::cout << "pos         = " << pos         << ", ";
 std::cout << "bits.size() = " << bits.size() << std::endl;
+		for (auto c : bits)
+			std::cout << int(c);
+std::cout << std::endl;
 */
 			BOOST_ASSERT((ex <= 0) and (pos < int(bits.size())) and (pos >= 0));
 			bits[pos] = 1;


### PR DESCRIPTION
I did a little bit of investigation involving that [class DecomposedReal](https://github.com/boostorg/multiprecision/pull/249#discussion_r439844758) to examine the bits and I am becoming worried that it could be difficult to make it work without handling these implicit bits.

I have just pushed my experiments in a new PR https://github.com/BoostGSoC21/multiprecision/pull/28

I added a new file test/test_cpp_double_float_decomposition.cpp and the first test for `long double` will pass when we remove "-2" from [here](https://github.com/BoostGSoC21/multiprecision/pull/28/files#diff-bb9459c4a1f6866e23101b1428b9f6a910b63310156b202b3946d414fcb92071R1147). Uncommenting [other types](https://github.com/BoostGSoC21/multiprecision/pull/28/files#diff-8ce98636352ad37d2f0d1f88c11d031b89c5ca520570fa2db2f5ff520587ddeaR166) is crashing for now.