### PR TITLE
Almost complete float128 support in tests

### DIFF
--- a/.github/workflows/multiprecision_quad_double_only.yml
+++ b/.github/workflows/multiprecision_quad_double_only.yml
@@ -81,6 +81,73 @@ jobs:
           ls -la ./test_cpp_double_float_constructors.exe
           echo "execute ./test_cpp_double_float_constructors.exe"
           ./test_cpp_double_float_constructors.exe
+  gcc-clang-native-asan:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ g++, clang++ ]
+        standard: [ c++11, c++14, c++17, c++2a ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: clone-submods-bootstrap-headers-boost-develop
+        run: |
+          git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
+          cd ../boost-root
+          git submodule update --init tools
+          git submodule update --init libs/array
+          git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
+          git submodule update --init libs/config
+          git submodule update --init libs/container
+          git submodule update --init libs/core
+          git submodule update --init libs/detail
+          git submodule update --init libs/exception
+          git submodule update --init libs/headers
+          git submodule update --init libs/integer
+          git submodule update --init libs/iterator
+          git submodule update --init libs/lexical_cast
+          git submodule update --init libs/math
+          git submodule update --init libs/move
+          git submodule update --init libs/mpl
+          git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
+          git submodule update --init libs/preprocessor
+          git submodule update --init libs/rational
+          git submodule update --init libs/range
+          git submodule update --init libs/smart_ptr
+          git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
+          git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
+          ./bootstrap.sh
+          ./b2 headers
+      - name: gcc-clang-native-asan
+        run: |
+          echo "where am i (via pwd)"
+          pwd
+          echo "compile to ./test_cpp_double_float_arithmetic.exe"
+          echo "compiler version"
+          ${{ matrix.compiler }} -v
+          ${{ matrix.compiler }} -finline-functions -fsanitize=address -fsanitize=leak -m64 -O3 -Wall -Wextra -std=${{ matrix.standard }} -I./include -I../boost-root test/test_cpp_double_float_arithmetic.cpp -o test_cpp_double_float_arithmetic.exe
+          echo "ls -la of ./test_cpp_double_float_arithmetic.exe"
+          ls -la ./test_cpp_double_float_arithmetic.exe
+          echo "execute ./test_cpp_double_float_arithmetic.exe"
+          ./test_cpp_double_float_arithmetic.exe
+          echo "compile to ./test_cpp_double_float_constructors.exe"
+          echo "compiler version"
+          ${{ matrix.compiler }} -v
+          ${{ matrix.compiler }} -finline-functions -fsanitize=address -fsanitize=leak -m64 -O3 -Wall -Wextra -std=${{ matrix.standard }} -I./include -I../boost-root test/test_cpp_double_float_constructors.cpp -o test_cpp_double_float_constructors.exe
+          echo "ls -la of ./test_cpp_double_float_constructors.exe"
+          ls -la ./test_cpp_double_float_constructors.exe
+          echo "execute ./test_cpp_double_float_constructors.exe"
+          ./test_cpp_double_float_constructors.exe
   apple-gcc-clang-native:
     runs-on: macos-latest
     defaults:

--- a/example/q_float/q_float/q_float.cpp
+++ b/example/q_float/q_float/q_float.cpp
@@ -49,7 +49,9 @@ q_float::q_float(const double d)
     from_uint64(static_cast<INT64>(0.5 + dd / double_p10(n_exp - (std::numeric_limits<double>::digits10 - 1))));
 
     // Re-scale with the appropriate power of ten.
-    operator*=(qf::pow10(n_exp - (std::numeric_limits<double>::digits10 - 1)));
+    const q_float p10(qf::pow10(n_exp - (std::numeric_limits<double>::digits10 - 1)));
+
+    operator*=(p10);
 
     if(b_neg)
     {

--- a/example/q_float/q_float/q_float.h
+++ b/example/q_float/q_float/q_float.h
@@ -281,7 +281,7 @@
       // Algorithm from Victor Shoup, package WinNTL-5_3_2, slightly modified.
       volatile double C  = hi / v.hi;
       double c  = split() * C;
-      double hc = c - C;
+      volatile double hc = c - C;
       double u  = split() * v.hi;
       hc = c - hc;
       const double tc = C - hc;
@@ -490,6 +490,9 @@
     static bool dump_digits(const q_float& x, std::string& str);
 
     void dump(void) const { dump(*this, std::cout); }
+
+    double rep_hi() const { return hi; }
+    double rep_lo() const { return lo; }
 
   private:
     double hi;

--- a/example/q_float/q_float/q_float_limits.h
+++ b/example/q_float/q_float/q_float_limits.h
@@ -23,7 +23,7 @@
       static const bool  is_bounded        = true;
       static const bool  is_modulo         = false;
       static const bool  is_iec559         = false;
-      static const INT32 digits            = 102;
+      static const INT32 digits            = 104;
       static const INT32 digits10          = static_cast<INT32>(float(digits) * 0.301029995663981195F);
       static const INT32 radix             = 2;
       static const INT32 round_style       = std::round_to_nearest;

--- a/example/q_float/test.cpp
+++ b/example/q_float/test.cpp
@@ -186,7 +186,7 @@ namespace local
     dist_dec_pt
     (
       1,
-      (int) (std::max)(std::ptrdiff_t(2) , std::ptrdiff_t(std::ptrdiff_t(DigitsToGet) - 4))
+      (int) (std::max)(std::ptrdiff_t(2), std::ptrdiff_t(std::ptrdiff_t(DigitsToGet) - 4))
     );
 
     static std::uniform_int_distribution<unsigned>
@@ -247,37 +247,61 @@ namespace local
 
       ++pos;
     }
+
+    const bool exp_is_neg = (dist_sgn(engine_sgn) != 0);
+
+    static std::uniform_int_distribution<unsigned>
+    dist_exp
+    (
+      0,
+      110
+    );
+
+    std::string str_exp = ((exp_is_neg == false) ? "E+" :  "E-");
+
+    {
+      std::stringstream strm;
+
+      strm << dist_exp(engine_man);
+
+      str_exp += strm.str();
+    }
+
+    str += str_exp;
+  }
+
+  template<typename ConstructionType>
+  ConstructionType construct_from(const naked_double_float_type& f)
+  {
+    return ConstructionType(f.rep_hi()) + ConstructionType(f.rep_lo());
   }
 
   bool test_add__(const unsigned count)
   {
     bool result_is_ok = true;
 
-    for(unsigned i = 0U; i < count; ++i)
+    const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<naked_double_float_type>::digits + 0);
+
+    for(unsigned i = 0U; ((i < count) && result_is_ok); ++i)
     {
       std::string str_a;
       std::string str_b;
 
-      local::get_random_fixed_string<33U>(str_a);
-      local::get_random_fixed_string<33U>(str_b);
+      local::get_random_fixed_string<35U>(str_a);
+      local::get_random_fixed_string<35U>(str_b);
 
       const naked_double_float_type df_a  (str_a);
       const naked_double_float_type df_b  (str_b);
 
-      const control_float_type      ctrl_a(str_a);
-      const control_float_type      ctrl_b(str_b);
+      const control_float_type      ctrl_a = construct_from<control_float_type>(df_a);
+      const control_float_type      ctrl_b = construct_from<control_float_type>(df_b);
 
       naked_double_float_type df_c    = df_a   + df_b;
       control_float_type      ctrl_c  = ctrl_a + ctrl_b;
 
-      std::stringstream strm;
+      const control_float_type delta = fabs(1 - fabs(ctrl_c / construct_from<control_float_type>(df_c)));
 
-      strm << std::setprecision(33) << df_c;
-
-      const std::string str_df_c = strm.str();
-
-      const bool b_ok =
-        (fabs(1 - fabs(ctrl_c / control_float_type(str_df_c))) < std::numeric_limits<control_float_type>::epsilon() * 10000UL);
+      const bool b_ok = (delta < (MaxError * 1UL));
 
       result_is_ok &= b_ok;
     }
@@ -289,31 +313,28 @@ namespace local
   {
     bool result_is_ok = true;
 
-    for(unsigned i = 0U; i < count; ++i)
+    const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<naked_double_float_type>::digits + 0);
+
+    for(unsigned i = 0U; ((i < count) && result_is_ok); ++i)
     {
       std::string str_a;
       std::string str_b;
 
-      local::get_random_fixed_string<33U>(str_a);
-      local::get_random_fixed_string<33U>(str_b);
+      local::get_random_fixed_string<35U>(str_a);
+      local::get_random_fixed_string<35U>(str_b);
 
       const naked_double_float_type df_a  (str_a);
       const naked_double_float_type df_b  (str_b);
 
-      const control_float_type      ctrl_a(str_a);
-      const control_float_type      ctrl_b(str_b);
+      const control_float_type      ctrl_a = construct_from<control_float_type>(df_a);
+      const control_float_type      ctrl_b = construct_from<control_float_type>(df_b);
 
       naked_double_float_type df_c    = df_a   - df_b;
       control_float_type      ctrl_c  = ctrl_a - ctrl_b;
 
-      std::stringstream strm;
+      const control_float_type delta = fabs(1 - fabs(ctrl_c / construct_from<control_float_type>(df_c)));
 
-      strm << std::setprecision(33) << df_c;
-
-      const std::string str_df_c = strm.str();
-
-      const bool b_ok =
-        (fabs(1 - fabs(ctrl_c / control_float_type(str_df_c))) < std::numeric_limits<control_float_type>::epsilon() * 10000UL);
+      const bool b_ok = (delta < (MaxError * 1UL));
 
       result_is_ok &= b_ok;
     }
@@ -325,31 +346,28 @@ namespace local
   {
     bool result_is_ok = true;
 
-    for(unsigned i = 0U; i < count; ++i)
+    const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<naked_double_float_type>::digits + 0);
+
+    for(unsigned i = 0U; ((i < count) && result_is_ok); ++i)
     {
       std::string str_a;
       std::string str_b;
 
-      local::get_random_fixed_string<33U>(str_a);
-      local::get_random_fixed_string<33U>(str_b);
+      local::get_random_fixed_string<35U>(str_a);
+      local::get_random_fixed_string<35U>(str_b);
 
       const naked_double_float_type df_a  (str_a);
       const naked_double_float_type df_b  (str_b);
 
-      const control_float_type      ctrl_a(str_a);
-      const control_float_type      ctrl_b(str_b);
+      const control_float_type      ctrl_a = construct_from<control_float_type>(df_a);
+      const control_float_type      ctrl_b = construct_from<control_float_type>(df_b);
 
       naked_double_float_type df_c    = df_a   * df_b;
       control_float_type      ctrl_c  = ctrl_a * ctrl_b;
 
-      std::stringstream strm;
+      const control_float_type delta = fabs(1 - fabs(ctrl_c / construct_from<control_float_type>(df_c)));
 
-      strm << std::setprecision(33) << df_c;
-
-      const std::string str_df_c = strm.str();
-
-      const bool b_ok =
-        (fabs(1 - fabs(ctrl_c / control_float_type(str_df_c))) < std::numeric_limits<control_float_type>::epsilon() * 10000UL);
+      const bool b_ok = (delta < (MaxError * 2UL));
 
       result_is_ok &= b_ok;
     }
@@ -361,31 +379,28 @@ namespace local
   {
     bool result_is_ok = true;
 
-    for(unsigned i = 0U; i < count; ++i)
+    const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<naked_double_float_type>::digits + 0);
+
+    for(unsigned i = 0U;((i < count) && result_is_ok); ++i)
     {
       std::string str_a;
       std::string str_b;
 
-      local::get_random_fixed_string<33U>(str_a);
-      local::get_random_fixed_string<33U>(str_b);
+      local::get_random_fixed_string<35U>(str_a);
+      local::get_random_fixed_string<35U>(str_b);
 
       const naked_double_float_type df_a  (str_a);
       const naked_double_float_type df_b  (str_b);
 
-      const control_float_type      ctrl_a(str_a);
-      const control_float_type      ctrl_b(str_b);
+      const control_float_type      ctrl_a = construct_from<control_float_type>(df_a);
+      const control_float_type      ctrl_b = construct_from<control_float_type>(df_b);
 
       naked_double_float_type df_c    = df_a   / df_b;
       control_float_type      ctrl_c  = ctrl_a / ctrl_b;
 
-      std::stringstream strm;
+      const control_float_type delta = fabs(1 - fabs(ctrl_c / construct_from<control_float_type>(df_c)));
 
-      strm << std::setprecision(33) << df_c;
-
-      const std::string str_df_c = strm.str();
-
-      const bool b_ok =
-        (fabs(1 - fabs(ctrl_c / control_float_type(str_df_c))) < std::numeric_limits<control_float_type>::epsilon() * 10000UL);
+      const bool b_ok = (delta < (MaxError * 2UL));
 
       result_is_ok &= b_ok;
     }
@@ -397,29 +412,25 @@ namespace local
   {
     bool result_is_ok = true;
 
-    for(unsigned i = 0U; i < count; ++i)
+    const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<naked_double_float_type>::digits + 0);
+
+    for(unsigned i = 0U; ((i < count) && result_is_ok); ++i)
     {
       std::string str_a;
       std::string str_b;
 
-      local::get_random_fixed_string<33U>(str_a, true);
+      local::get_random_fixed_string<35U>(str_a, true);
 
       const naked_double_float_type df_a  (str_a);
-      const naked_double_float_type df_b  (str_b);
 
-      const control_float_type      ctrl_a(str_a);
+      const control_float_type      ctrl_a = construct_from<control_float_type>(df_a);
 
       naked_double_float_type df_c    = qf::sqrt(df_a);
       control_float_type      ctrl_c  = sqrt(ctrl_a);
 
-      std::stringstream strm;
+      const control_float_type delta = fabs(1 - fabs(ctrl_c / construct_from<control_float_type>(df_c)));
 
-      strm << std::setprecision(33) << df_c;
-
-      const std::string str_df_c = strm.str();
-
-      const bool b_ok =
-        (fabs(1 - fabs(ctrl_c / control_float_type(str_df_c))) < std::numeric_limits<control_float_type>::epsilon() * 10000UL);
+      const bool b_ok = (delta < (MaxError * 1UL));
 
       result_is_ok &= b_ok;
     }
@@ -432,11 +443,15 @@ int main()
 {
   local::test_spot();
 
-  const bool result_add___is_ok = local::test_add__(1024U); std::cout << "result_add___is_ok: " << std::boolalpha << result_add___is_ok << std::endl;
-  const bool result_sub___is_ok = local::test_sub__(1024U); std::cout << "result_sub___is_ok: " << std::boolalpha << result_sub___is_ok << std::endl;
-  const bool result_mul___is_ok = local::test_mul__(1024U); std::cout << "result_mul___is_ok: " << std::boolalpha << result_mul___is_ok << std::endl;
-  const bool result_div___is_ok = local::test_div__(1024U); std::cout << "result_div___is_ok: " << std::boolalpha << result_div___is_ok << std::endl;
-  const bool result_sqrt__is_ok = local::test_sqrt_(1024U); std::cout << "result_sqrt__is_ok: " << std::boolalpha << result_sqrt__is_ok << std::endl;
+  constexpr unsigned int count = 0x10000UL << 7U;
+
+  std::cout << "Testing " << count << " arithmetic cases." << std::endl;
+
+  const bool result_add___is_ok = local::test_add__(count); std::cout << "result_add___is_ok: " << std::boolalpha << result_add___is_ok << std::endl;
+  const bool result_sub___is_ok = local::test_sub__(count); std::cout << "result_sub___is_ok: " << std::boolalpha << result_sub___is_ok << std::endl;
+  const bool result_mul___is_ok = local::test_mul__(count); std::cout << "result_mul___is_ok: " << std::boolalpha << result_mul___is_ok << std::endl;
+  const bool result_div___is_ok = local::test_div__(count); std::cout << "result_div___is_ok: " << std::boolalpha << result_div___is_ok << std::endl;
+  const bool result_sqrt__is_ok = local::test_sqrt_(count); std::cout << "result_sqrt__is_ok: " << std::boolalpha << result_sqrt__is_ok << std::endl;
 
   const bool result_all_is_ok = (   result_add___is_ok
                                  && result_sub___is_ok

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -53,24 +53,27 @@ class cpp_double_float
 
    // Constructors
    cpp_double_float() { }
-   
+
    // default constructor
    constexpr cpp_double_float(const cpp_double_float& a) : data(a.data) {}
 
    // Constructors from other floating-point types
    template <typename FloatType,
-             typename std::enable_if<(std::is_floating_point<FloatType>::value == true)
-             && (std::numeric_limits<FloatType>::digits <= std::numeric_limits<float_type>::digits)>::type const* = nullptr>
+             typename std::enable_if<(   (std::is_floating_point<FloatType>::value == true)
+                                      && (std::numeric_limits<FloatType>::digits <= std::numeric_limits<float_type>::digits))>::type const* = nullptr>
    constexpr cpp_double_float(const FloatType& f) : data(std::make_pair(f, (float_type)0)) {}
+
    template <typename FloatType,
-             typename std::enable_if<(std::numeric_limits<FloatType>::is_iec559 == true)
-             && (std::numeric_limits<FloatType>::digits > std::numeric_limits<float_type>::digits)>::type const* = nullptr>
+             typename std::enable_if<(   (std::numeric_limits<FloatType>::is_iec559 == true)
+                                      && (std::numeric_limits<FloatType>::digits > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
    constexpr cpp_double_float(const FloatType& f)
        : data(std::make_pair(static_cast<float_type>(f),
                              static_cast<float_type>(f - (FloatType) static_cast<float_type>(f)))) {}
 
    // Constructor from other cpp_double_float<> objects
-   template <typename OtherFloatType, typename std::enable_if<!std::is_same<FloatingPointType, OtherFloatType>::value>::type const* = nullptr>
+   template <typename OtherFloatType,
+             typename std::enable_if<(   (std::is_floating_point<OtherFloatType>::value == true)
+                                      && (std::is_same<FloatingPointType, OtherFloatType>::value == false))>::type const* = nullptr>
    cpp_double_float(const cpp_double_float<OtherFloatType>& a)
        : cpp_double_float(a.first())
    {
@@ -80,20 +83,21 @@ class cpp_double_float
 
    // Constructors from integers
    template <typename IntegralType,
-             typename std::enable_if<(std::is_integral<IntegralType>::value == true) && (std::numeric_limits<IntegralType>::digits <= std::numeric_limits<FloatingPointType>::digits)>::type const* = nullptr>
+             typename std::enable_if<(   (std::is_integral<IntegralType>::value == true)
+                                      && (std::numeric_limits<IntegralType>::digits <= std::numeric_limits<FloatingPointType>::digits))>::type const* = nullptr>
    constexpr cpp_double_float(const IntegralType& f) : data(std::make_pair(static_cast<float_type>(f), (float_type)0)) {}
 
    // Constructors from integers which hold more information than *this can contain
    template <typename UnsignedIntegralType,
-             typename std::enable_if<((std::is_integral<UnsignedIntegralType>::value == true)
-               && (std::is_unsigned<UnsignedIntegralType>::value == true)
-               && (std::numeric_limits<UnsignedIntegralType>::digits > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
+             typename std::enable_if<(    (std::is_integral<UnsignedIntegralType>::value == true)
+                                       && (std::is_unsigned<UnsignedIntegralType>::value == true)
+                                       && (std::numeric_limits<UnsignedIntegralType>::digits > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
    cpp_double_float(UnsignedIntegralType u);
 
    template <typename SignedIntegralType,
-             typename std::enable_if<((std::is_integral<SignedIntegralType>::value == true)
-               && (std::is_signed<SignedIntegralType>::value == true)
-               && (std::numeric_limits<SignedIntegralType>::digits + 1 > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
+             typename std::enable_if<(   (std::is_integral<SignedIntegralType>::value == true)
+                                      && (std::is_signed<SignedIntegralType>::value == true)
+                                      && (std::numeric_limits<SignedIntegralType>::digits + 1 > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
    cpp_double_float(SignedIntegralType n) : cpp_double_float(static_cast<typename std::make_unsigned<SignedIntegralType>::type>(std::abs(n)))
    {
       if (n < 0)
@@ -113,19 +117,19 @@ class cpp_double_float
    ~cpp_double_float() = default;
 
    // Casts
-   operator signed char() const { return (signed char)data.first; }
-   operator signed short() const { return (signed short)data.first; }
-   operator signed int() const { return (signed int)data.first + (signed int)data.second; }
-   operator signed long() const { return (signed long)data.first + (signed long)data.second; }
-   operator signed long long() const { return (signed long long)data.first + (signed long long)data.second; }
-   operator unsigned char() const { return (unsigned char)data.first; }
-   operator unsigned short() const { return (unsigned short)data.first; }
-   operator unsigned int() const { return (unsigned int)((unsigned int)data.first + (signed int)data.second); }
-   operator unsigned long() const { return (unsigned long)((unsigned long)data.first + (signed long)data.second); }
+   operator   signed char     () const { return (signed char)data.first; }
+   operator   signed short    () const { return (signed short)data.first; }
+   operator   signed int      () const { return (signed int)data.first + (signed int)data.second; }
+   operator   signed long     () const { return (signed long)data.first + (signed long)data.second; }
+   operator   signed long long() const { return (signed long long)data.first + (signed long long)data.second; }
+   operator unsigned char     () const { return (unsigned char)data.first; }
+   operator unsigned short    () const { return (unsigned short)data.first; }
+   operator unsigned int      () const { return (unsigned int)((unsigned int)data.first + (signed int)data.second); }
+   operator unsigned long     () const { return (unsigned long)((unsigned long)data.first + (signed long)data.second); }
    operator unsigned long long() const { return (unsigned long long)((unsigned long long)data.first + (signed long long)data.second); }
-   operator float() const { return (float)data.first + (float)data.second; }
-   operator double() const { return (double)data.first + (double)data.second; }
-   operator long double() const { return (long double)data.first + (long double)data.second; }
+   operator float             () const { return (float)data.first + (float)data.second; }
+   operator double            () const { return (double)data.first + (double)data.second; }
+   operator long double       () const { return (long double)data.first + (long double)data.second; }
 
    // Methods
    constexpr cpp_double_float<float_type> negative()    const { return cpp_double_float<float_type>(-data.first, -data.second); }
@@ -142,23 +146,39 @@ class cpp_double_float
    const rep_type&  rep() const { return data; }
    const rep_type& crep() const { return data; }
 
-   // Helper functions
-   static std::pair<float_type, float_type> fast_exact_sum(const float_type& a, const float_type& b);
-   static std::pair<float_type, float_type> exact_sum(const float_type& a, const float_type& b);
-   static std::pair<float_type, float_type> exact_difference(const float_type& a, const float_type& b);
-   static std::pair<float_type, float_type> exact_product(const float_type& a, const float_type& b);
-
-   static std::pair<float_type, float_type> split(const float_type& a);
-
-   static void normalize_pair(std::pair<float_type, float_type>& p, bool fast = true);
-
    // Operators
    cpp_double_float& operator=(const cpp_double_float&) = default;
 
    cpp_double_float& operator=(cpp_double_float&&) = default;
 
-   cpp_double_float& operator+=(const cpp_double_float& a);
-   cpp_double_float& operator-=(const cpp_double_float& a);
+   cpp_double_float& operator+=(const cpp_double_float& other)
+   {
+      const rep_type t = exact_sum(second(), other.second());
+
+      data = exact_sum(first(),  other.first());
+
+      data.second += t.first;
+      normalize_pair(data);
+      data.second += t.second;
+      normalize_pair(data);
+
+      return *this;
+   }
+
+   cpp_double_float& operator-=(const cpp_double_float& other)
+   {
+      const rep_type t = exact_difference(second(), other.second());
+      data = exact_difference(first(), other.first());
+
+      data.second += t.first;
+      normalize_pair(data);
+
+      data.second += t.second;
+      normalize_pair(data);
+
+      return *this;
+   }
+
    cpp_double_float& operator*=(const cpp_double_float& a);
    cpp_double_float& operator/=(const cpp_double_float& a);
    cpp_double_float& operator+=(const float_type& a);
@@ -167,16 +187,26 @@ class cpp_double_float
    cpp_double_float& operator/=(const float_type& a);
    cpp_double_float  operator++(int);
    cpp_double_float  operator--(int);
-   cpp_double_float& operator++() { return *this += cpp_double_float<float_type>((double)1.); }
-   cpp_double_float& operator--() { return *this -= cpp_double_float<float_type>(1.); }
+   cpp_double_float& operator++() { return *this += cpp_double_float<float_type>(float_type(1.0F)); }
+   cpp_double_float& operator--() { return *this -= cpp_double_float<float_type>(float_type(1.0F)); }
    cpp_double_float  operator-() const { return negative(); }
 
-   // -- DEBUGGING
    std::string get_raw_str() const;
-   // --
+
+   // Helper functions
+   static std::pair<float_type, float_type> fast_exact_sum(const float_type& a, const float_type& b);
+   static std::pair<float_type, float_type> exact_sum(const float_type& a, const float_type& b);
+   static std::pair<float_type, float_type> exact_difference(const float_type& a, const float_type& b);
+   static std::pair<float_type, float_type> exact_product(const float_type& a, const float_type& b);
+
+   static void normalize_pair(std::pair<float_type, float_type>& p, bool fast = true);
+
    static cpp_double_float<float_type> pow10(int x);
+
  private:
    rep_type data;
+
+   static std::pair<float_type, float_type> split(const float_type& a);
 };
 
 // -- Special Constructors
@@ -345,21 +375,15 @@ template <typename FloatingPointType>
 inline cpp_double_float<FloatingPointType>
 operator+(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b)
 {
-   using double_float_t = cpp_double_float<FloatingPointType>;
-
-   std::pair<FloatingPointType, FloatingPointType> s, t;
-
-   s = double_float_t::exact_sum(a.first(), b.first());
-   t = double_float_t::exact_sum(a.second(), b.second());
-
-   s.second += t.first;
-   double_float_t::normalize_pair(s);
-   s.second += t.second;
-   double_float_t::normalize_pair(s);
-
-   return double_float_t(s);
+   return cpp_double_float<FloatingPointType>(a) += b;
 }
 
+template <typename FloatingPointType>
+inline cpp_double_float<FloatingPointType>
+operator-(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b)
+{
+   return cpp_double_float<FloatingPointType>(a) -= b;
+}
 
 // double_float<> - native-float
 template <typename FloatingPointType>
@@ -371,27 +395,6 @@ operator-(const cpp_double_float<FloatingPointType>& a, const FloatingPointType&
    auto s = double_float_t::exact_difference(a.first(), b);
 
    s.second += a.second();
-   double_float_t::normalize_pair(s);
-
-   return double_float_t(s);
-}
-
-// double_float<> - double_float<>
-template <typename FloatingPointType>
-inline cpp_double_float<FloatingPointType>
-operator-(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b)
-{
-   using double_float_t = cpp_double_float<FloatingPointType>;
-
-   typename double_float_t::rep_type s, t;
-
-   s = double_float_t::exact_difference(a.first(), b.first());
-   t = double_float_t::exact_difference(a.second(), b.second());
-
-   s.second += t.first;
-   double_float_t::normalize_pair(s);
-
-   s.second += t.second;
    double_float_t::normalize_pair(s);
 
    return double_float_t(s);
@@ -535,23 +538,6 @@ inline void cpp_double_float<FloatingPointType>::set_str(std::string str)
    }
 
    *this *= pow10(final_exponent);
-}
-
-// -- Overloaded operators
-template <typename FloatingPointType>
-inline cpp_double_float<FloatingPointType>&
-cpp_double_float<FloatingPointType>::operator+=(const cpp_double_float<FloatingPointType>& a)
-{
-   *this = *this + a;
-   return *this;
-}
-
-template <typename FloatingPointType>
-inline cpp_double_float<FloatingPointType>&
-cpp_double_float<FloatingPointType>::operator-=(const cpp_double_float<FloatingPointType>& a)
-{
-   *this = *this - a;
-   return *this;
 }
 
 template <typename FloatingPointType>
@@ -1139,27 +1125,33 @@ inline std::string cpp_double_float<FloatingPointType>::get_raw_str() const
 
 // Specialization of numeric_limits for cpp_double_float<>
 template <typename FloatingPointType>
-class std::numeric_limits<boost::multiprecision::backends::cpp_double_float<FloatingPointType> > : public std::numeric_limits<FloatingPointType>
+class std::numeric_limits<boost::multiprecision::backends::cpp_double_float<FloatingPointType>>
+  : public std::numeric_limits<FloatingPointType>
 {
- public:
-   static constexpr bool is_iec559 = false;
+private:
+   using base_class_type = std::numeric_limits<FloatingPointType>;
 
-   static constexpr int digits       = 2 * std::numeric_limits<FloatingPointType>::digits - 2;
-   static constexpr int digits10     =  int(float(digits - 1) * 0.301F);
-   static constexpr int max_digits10 =  int(float(digits)     * 0.301F) + 2;
+   using self_type = boost::multiprecision::backends::cpp_double_float<FloatingPointType>;
 
-   static constexpr int max_exponent = std::numeric_limits<FloatingPointType>::max_exponent - std::numeric_limits<FloatingPointType>::digits;
-   static constexpr int min_exponent = std::numeric_limits<FloatingPointType>::min_exponent + std::numeric_limits<FloatingPointType>::digits;
+public:
+   static constexpr bool is_iec559   = false;
 
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType>(min)() noexcept { return (std::numeric_limits<FloatingPointType>::min)(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType>(max)() noexcept { return (std::numeric_limits<FloatingPointType>::max)(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> lowest() noexcept { return std::numeric_limits<FloatingPointType>::lowest(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> epsilon() noexcept {return std::numeric_limits<FloatingPointType>::epsilon(); } // NOTE: doesn't construct from float128
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> round_error() noexcept { return std::numeric_limits<FloatingPointType>::round_error(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> denorm_min() noexcept { return std::numeric_limits<FloatingPointType>::denorm_min(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> infinity() noexcept { return std::numeric_limits<FloatingPointType>::infinity(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> quiet_NaN() noexcept { return std::numeric_limits<FloatingPointType>::quiet_NaN(); }
-   static constexpr boost::multiprecision::backends::cpp_double_float<FloatingPointType> signaling_NaN() noexcept { return std::numeric_limits<FloatingPointType>::signaling_NaN(); }
+   static constexpr int digits       = (2 * base_class_type::digits) - 2;
+   static constexpr int digits10     = int(float(digits - 1) * 0.301F);
+   static constexpr int max_digits10 = int(float(digits)     * 0.301F) + 2;
+
+   static constexpr int max_exponent = std::numeric_limits<FloatingPointType>::max_exponent - base_class_type::digits;
+   static constexpr int min_exponent = std::numeric_limits<FloatingPointType>::min_exponent + base_class_type::digits;
+
+   static constexpr self_type (min)         () noexcept { return self_type((base_class_type::min)()); }
+   static constexpr self_type (max)         () noexcept { return self_type((base_class_type::max)()); }
+   static constexpr self_type  lowest       () noexcept { return self_type( base_class_type::lowest()); }
+   static constexpr self_type  epsilon      () noexcept { return self_type( base_class_type::epsilon()); } // NOTE: doesn't construct from float128
+   static constexpr self_type  round_error  () noexcept { return self_type( base_class_type::round_error()); }
+   static constexpr self_type  denorm_min   () noexcept { return self_type( base_class_type::denorm_min()); }
+   static constexpr self_type  infinity     () noexcept { return self_type( base_class_type::infinity()); }
+   static constexpr self_type  quiet_NaN    () noexcept { return self_type( base_class_type::quiet_NaN()); }
+   static constexpr self_type  signaling_NaN() noexcept { return self_type( base_class_type::signaling_NaN()); }
 };
 // TODO have explicit specializations for cpp_double_float< float/double >
 

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -35,20 +35,21 @@ or std::is_same<FloatingPointType,boost::multiprecision::float128>::value
 #endif
 ;
 
-template <typename FloatingPointType,
-          typename std::enable_if<is_floating_point<FloatingPointType>::value, bool>::type = true>
-FloatingPointType uniform_real()
+template<typename FloatingPointType> 
+typename std::enable_if<(std::is_floating_point<FloatingPointType>::value == true), FloatingPointType>::type uniform_real()
 {
-   static std::random_device                                rd;
-   static std::mt19937                                      gen (rd());
-   static boost::random::uniform_real_distribution<FloatingPointType> dis(0.0, 1.0);
+   using distribution_type = boost::random::uniform_real_distribution<FloatingPointType>;
+
+   static std::random_device   rd;
+   static std::mt19937         gen (rd());
+   static distribution_type    dis(0.0, 1.0);
 
    return dis(gen);
 }
 
 int rand_in_range(int a, int b)
 {
-   return a + int(float(b - a) * uniform_real<float>());
+   return a + int(float(b - a) * test_arithmetic_cpp_double_float::uniform_real<float>());
 }
 
 template <typename FloatingPointType,
@@ -65,8 +66,8 @@ boost::multiprecision::backends::cpp_double_float<typename FloatingPointType::fl
    return boost::multiprecision::backends::cpp_double_float<float_type>(uniform_real<float_type>()) * boost::multiprecision::backends::cpp_double_float<float_type>(uniform_real<float_type>());
 }
 
-template <typename FloatingPointType, typename std::enable_if<is_floating_point<FloatingPointType>::value>::type const* = nullptr>
-FloatingPointType log_rand()
+template<typename FloatingPointType> 
+typename std::enable_if<(std::is_floating_point<FloatingPointType>::value == true), FloatingPointType>::type log_rand()
 {
    if (uniform_real<float>() < (1. / 100.))
       return 0; // throw in a few zeroes
@@ -96,7 +97,7 @@ ConstructionType construct_from(FloatingPointType f)
 }
 
 template <typename FloatingPointType>
-int test_op(char op, const unsigned count = 10000U)
+int test_op(char op, const unsigned count = 0x10000U)
 {
    using naked_double_float_type = FloatingPointType;
    using control_float_type      = boost::multiprecision::number<boost::multiprecision::cpp_dec_float<std::numeric_limits<naked_double_float_type>::digits10 * 2 + 1>, boost::multiprecision::et_off>;

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -11,6 +11,9 @@
 // cd /mnt/c/Users/User/Documents/Ks/PC_Software/Test
 // g++ -O3 -Wall -march=native -std=c++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 test.cpp -o test_double_float.exe
 
+// TBD: Handle interaction with Boost's wrap of libquadmath __float128.
+// g++ -O3 -Wall -march=native -std=gnu++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 -DBOOST_MATH_USE_FLOAT128 test.cpp -o -lquadmath test_double_float.exe
+
 #include <boost/config.hpp>
 #include <boost/multiprecision/cpp_double_float.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -15,12 +15,13 @@
 // g++ -O3 -Wall -march=native -std=gnu++11 -I/mnt/c/MyGitRepos/BoostGSoC21_multiprecision/include -I/mnt/c/boost/boost_1_76_0 -DBOOST_MATH_USE_FLOAT128 test.cpp -o -lquadmath test_double_float.exe
 
 #include <boost/config.hpp>
-#include <boost/multiprecision/cpp_double_float.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/multiprecision/number.hpp>
 #ifdef BOOST_MATH_USE_FLOAT128
 #include <boost/multiprecision/float128.hpp>
 #endif
+#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
 #include <boost/core/demangle.hpp>
 #include <iomanip>
 #include <iostream>
@@ -31,11 +32,7 @@
 namespace test_arithmetic_cpp_double_float {
 
 template <typename FloatingPointType,
-          typename std::enable_if<(  std::is_floating_point<FloatingPointType>::value                       == true
-#ifdef BOOST_MATH_USE_FLOAT128
-                                   ||std::is_same<FloatingPointType,boost::multiprecision::float128>::value == true
-#endif
-                                  ), bool>::type = true>
+          typename std::enable_if<(  boost::multiprecision::backends::detail::is_floating_point_or_float128<FloatingPointType>::value == true), bool>::type = true>
 FloatingPointType uniform_real()
 {
    static std::random_device                                rd;
@@ -51,11 +48,7 @@ int rand_in_range(int a, int b)
 }
 
 template <typename FloatingPointType,
-          typename std::enable_if<(  std::is_floating_point<FloatingPointType>::value                       == true
-#ifdef BOOST_MATH_USE_FLOAT128
-                                   ||std::is_same<FloatingPointType,boost::multiprecision::float128>::value == true
-#endif
-                                  ), bool>::type = true>
+          typename std::enable_if<(  boost::multiprecision::backends::detail::is_floating_point_or_float128<FloatingPointType>::value == true), bool>::type = true>
 FloatingPointType uniform_rand()
 {
    return uniform_real<FloatingPointType>();
@@ -70,11 +63,7 @@ boost::multiprecision::backends::cpp_double_float<typename FloatingPointType::fl
 
 
 template <typename FloatingPointType>
-typename std::enable_if<(  std::is_floating_point<FloatingPointType>::value                       == true
-#ifdef BOOST_MATH_USE_FLOAT128
-                         ||std::is_same<FloatingPointType,boost::multiprecision::float128>::value == true
-#endif
-                        ), FloatingPointType>::type
+typename std::enable_if<(  boost::multiprecision::backends::detail::is_floating_point_or_float128<FloatingPointType>::value == true), FloatingPointType>::type
 log_rand()
 {
    if (uniform_real<float>() < (1. / 100.))

--- a/test/test_cpp_double_float_decomposition.cpp
+++ b/test/test_cpp_double_float_decomposition.cpp
@@ -10,12 +10,13 @@
 
 
 #include <boost/config.hpp>
-#include <boost/multiprecision/cpp_double_float.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/multiprecision/number.hpp>
 #ifdef BOOST_MATH_USE_FLOAT128
 #include <boost/multiprecision/float128.hpp>
 #endif
+#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
 #include <boost/core/demangle.hpp>
 #include <iomanip>
 #include <iostream>

--- a/test/test_cpp_double_float_io.cpp
+++ b/test/test_cpp_double_float_io.cpp
@@ -11,10 +11,11 @@
 
 
 #include <boost/config.hpp>
-#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/multiprecision/number.hpp>
 #ifdef BOOST_MATH_USE_FLOAT128
 #include <boost/multiprecision/float128.hpp>
 #endif
+#include <boost/multiprecision/cpp_double_float.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 #include <iostream>
 #include <cstdlib>
@@ -22,18 +23,8 @@
 
 namespace test_cpp_double_float_io {
 
-// FIXME: this looks like a duplicate from test_cpp_double_float_comparision.cpp file.
-template<typename FloatingPointType> struct is_floating_point {
-static const bool value;
-};
-template<typename FloatingPointType> const bool is_floating_point<FloatingPointType>::value = std::is_floating_point<FloatingPointType>::value
-#ifdef BOOST_MATH_USE_FLOAT128
-or std::is_same<FloatingPointType,boost::multiprecision::float128>::value
-#endif
-;
-
 template <typename FloatingPointType,
-          typename std::enable_if<is_floating_point<FloatingPointType>::value, bool>::type = true>
+          typename std::enable_if<boost::multiprecision::backends::detail::is_floating_point_or_float128<FloatingPointType>::value, bool>::type = true>
 FloatingPointType uniform_real()
 {
    //static std::random_device                                rd;
@@ -55,7 +46,7 @@ int rand_in_range(int a, int b)
    return a + int(float(b - a) * uniform_real<float>());
 }
 
-template <typename FloatingPointType, typename std::enable_if<is_floating_point<FloatingPointType>::value>::type const* = nullptr>
+template <typename FloatingPointType, typename std::enable_if<boost::multiprecision::backends::detail::is_floating_point_or_float128<FloatingPointType>::value>::type const* = nullptr>
 FloatingPointType log_rand()
 {
    if (uniform_real<float>() < (1. / 100.))

--- a/test/test_cpp_double_float_io_manual.cpp
+++ b/test/test_cpp_double_float_io_manual.cpp
@@ -10,10 +10,11 @@
 // Note that the I/O of cpp_double_float<> is currently extremely underdeveloped
 
 #include <boost/config.hpp>
-#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/multiprecision/number.hpp>
 #ifdef BOOST_MATH_USE_FLOAT128
 #include <boost/multiprecision/float128.hpp>
 #endif
+#include <boost/multiprecision/cpp_double_float.hpp>
 #include <iostream>
 #include <cstdlib>
 


### PR DESCRIPTION
@ckormanyos , we did a little bit of work simulatenously, so I resolved small conflict with 3497de7d, d4a3aa1d. So your latest work is present in this PR.

Some organisation things are still to be decided, but for now, when I have put the duplicate tests for float128 in [single place](https://github.com/BoostGSoC21/multiprecision/blob/gsoc2021_double_float_janek/include/boost/multiprecision/cpp_double_float.hpp#L44) I was able to neatly uncomment all tests for float128.