### PR TITLE
Gsoc2021 double float ldbl specfun ci

### DIFF
--- a/.github/workflows/multiprecision_quad_double_only.yml
+++ b/.github/workflows/multiprecision_quad_double_only.yml
@@ -76,3 +76,65 @@ jobs:
       - name: Test
         run: ../../../b2 -j2 toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
         working-directory: ../boost-root/libs/multiprecision/test
+  ubuntu-focal-df_qf_quadmath_tests:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ g++ ]
+        standard: [ gnu++11, gnu++14, gnu++17, gnu++2a ]
+        suite: [ df_qf_quadmath_tests ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set TOOLSET
+        run: echo ${{ matrix.compiler }} | awk '/^g/ { print "TOOLSET=gcc" } /^clang/ { print "TOOLSET=clang" }' >> $GITHUB_ENV
+      - name: Add repository
+        continue-on-error: true
+        id: addrepo
+        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Retry Add Repo
+        continue-on-error: true
+        id: retry1
+        if: steps.addrepo.outcome=='failure'
+        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Retry Add Repo 2
+        continue-on-error: true
+        id: retry2
+        if: steps.retry1.outcome=='failure'
+        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Install packages
+        run: echo no packages to install at the moment
+      - name: Checkout main boost
+        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
+      - name: Update tools/boostdep
+        run: git submodule update --init tools/boostdep
+        working-directory: ../boost-root
+      - name: Copy files
+        run: cp -r $GITHUB_WORKSPACE/* libs/multiprecision
+        working-directory: ../boost-root
+      - name: Install deps
+        run: python tools/boostdep/depinst/depinst.py multiprecision
+        working-directory: ../boost-root
+      - name: Bootstrap
+        run: ./bootstrap.sh
+        working-directory: ../boost-root
+      - name: Generate headers
+        run: ./b2 headers
+        working-directory: ../boost-root
+      - name: Generate user config
+        run: 'echo "using $TOOLSET : : ${{ matrix.compiler }} : <cxxflags>-std=${{ matrix.standard }} ;" > ~/user-config.jam'
+        working-directory: ../boost-root
+      - name: Config info install
+        run: ../../../b2 config_info_travis_install toolset=$TOOLSET
+        working-directory: ../boost-root/libs/config/test
+      - name: Config info
+        run: ./config_info_travis
+        working-directory: ../boost-root/libs/config/test
+      - name: Test
+        run: ../../../b2 -j2 toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
+        working-directory: ../boost-root/libs/multiprecision/test

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -34,40 +34,6 @@ namespace boost { namespace multiprecision { namespace backends {
 template <typename FloatingPointType>
 class cpp_double_float;
 
-namespace detail {
-
-template <class T> struct is_arithmetic_or_float128
-{
-   static constexpr bool value = (   (std::is_arithmetic<T>::value == true)
-#if defined(BOOST_MATH_USE_FLOAT128)
-                                  || (std::is_same<typename std::decay<T>::type, boost::multiprecision::float128>::value == true)
-#endif
-                                 );
-};
-
-template <class T> struct is_floating_point_or_float128
-{
-   static constexpr bool value = (   (std::is_floating_point<T>::value == true)
-#if defined(BOOST_MATH_USE_FLOAT128)
-                                  || (std::is_same<typename std::decay<T>::type, boost::multiprecision::float128>::value == true)
-#endif
-                                 );
-};
-
-template<typename R>
-typename std::enable_if<boost::is_unsigned<R>::value == false, R>::type minus_max()
-{
-   return boost::is_signed<R>::value ? (std::numeric_limits<R>::min)() : -(std::numeric_limits<R>::max)();
-}
-
-template<typename R>
-typename std::enable_if<boost::is_unsigned<R>::value == true, R>::type minus_max()
-{
-   return 0;
-}
-
-}
-
 template<typename FloatingPointType> inline cpp_double_float<FloatingPointType> operator+(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b);
 template<typename FloatingPointType> inline cpp_double_float<FloatingPointType> operator-(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b);
 template<typename FloatingPointType> inline cpp_double_float<FloatingPointType> operator*(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b);
@@ -150,6 +116,252 @@ struct number_category<backends::cpp_double_float<FloatingPointType>>
 
 namespace backends {
 
+namespace detail {
+
+template <class T> struct is_arithmetic_or_float128
+{
+   static constexpr bool value = (   (std::is_arithmetic<T>::value == true)
+#if defined(BOOST_MATH_USE_FLOAT128)
+                                  || (std::is_same<typename std::decay<T>::type, boost::multiprecision::float128>::value == true)
+#endif
+                                 );
+};
+
+template <class T> struct is_floating_point_or_float128
+{
+   static constexpr bool value = (   (std::is_floating_point<T>::value == true)
+#if defined(BOOST_MATH_USE_FLOAT128)
+                                  || (std::is_same<typename std::decay<T>::type, boost::multiprecision::float128>::value == true)
+#endif
+                                 );
+};
+
+template<typename R>
+typename std::enable_if<boost::is_unsigned<R>::value == false, R>::type minus_max()
+{
+   return boost::is_signed<R>::value ? (std::numeric_limits<R>::min)() : -(std::numeric_limits<R>::max)();
+}
+
+template<typename R>
+typename std::enable_if<boost::is_unsigned<R>::value == true, R>::type minus_max()
+{
+   return 0;
+}
+
+// exact_arithmetic<> implements extended precision techniques that are used in
+// cpp_double_float and cpp_quad_float
+template <typename FloatingPointType>
+struct exact_arithmetic
+{
+   static_assert(detail::is_floating_point_or_float128<FloatingPointType>::value == true, "exact_arithmetic<> invoked with unknown floating-point type");
+   using float_type  = FloatingPointType;
+   using float_pair  = std::pair<float_type, float_type>;
+   using float_tuple = std::tuple<float_type, float_type, float_type, float_type>;
+
+   static float_pair split(const float_type& a)
+   {
+      // Split a floating point number in two (high and low) parts approximating the
+      // upper-half and lower-half bits of the float
+      //static_assert(std::numeric_limits<float_type>::is_iec559,
+      //              "double_float<> invoked with non-native floating-point unit");
+
+      // TODO Replace bit shifts with constexpr funcs or ldexp for better compaitibility
+      constexpr int        MantissaBits   = std::numeric_limits<float_type>::digits;
+      constexpr int        SplitBits      = MantissaBits / 2 + 1;
+      constexpr float_type Splitter       = FloatingPointType((1ULL << SplitBits) + 1);
+      const float_type     SplitThreshold = (std::numeric_limits<float_type>::max)() / (Splitter * 2);
+
+      float_type temp, hi, lo;
+
+      // Handle if multiplication with the splitter would cause overflow
+      if (a > SplitThreshold || a < -SplitThreshold)
+      {
+         constexpr float_type Normalizer = float_type(1ULL << (SplitBits + 1));
+
+         const float_type a_ = a / Normalizer;
+
+         temp = Splitter * a_;
+         hi   = temp - (temp - a_);
+         lo   = a_ - hi;
+
+         hi *= Normalizer;
+         lo *= Normalizer;
+      }
+      else
+      {
+         temp = Splitter * a;
+         hi   = temp - (temp - a);
+         lo   = a - hi;
+      }
+
+      return std::make_pair(hi, lo);
+   }
+
+   static float_pair fast_sum(const float_type& a, const float_type& b)
+   {
+      // Exact addition of two floating point numbers, given |a| > |b|
+      using std::fabs;
+      using std::isnormal;
+
+      float_pair out;
+      out.first  = a + b;
+      out.second = b - (out.first - a);
+
+      return out;
+   }
+
+   static float_pair sum(const float_type& a, const float_type& b)
+   {
+      // Exact addition of two floating point numbers
+      float_pair out;
+
+      out.first    = a + b;
+      float_type v = out.first - a;
+      out.second   = (a - (out.first - v)) + (b - v);
+
+      return out;
+   }
+
+   static void sum(float_pair& p, float_type& e)
+   {
+      using std::tie;
+
+      float_pair t;
+      float_type t_;
+
+      t                = sum(p.first, p.second);
+      tie(p.first, t_) = sum(e, t.first);
+      tie(p.second, e) = sum(t.second, t_);
+   }
+
+   static float_pair difference(const float_type& a, const float_type& b)
+   {
+      // Exact subtraction of two floating point numbers
+      float_pair out;
+
+      out.first    = a - b;
+      float_type v = out.first - a;
+      out.second   = (a - (out.first - v)) - (b + v);
+
+      return out;
+   }
+
+   static float_pair product(const float_type& a, const float_type& b)
+   {
+      // Exact product of two floating point numbers
+      const float_pair a_split = split(a);
+      const float_pair b_split = split(b);
+
+      const volatile float_type pf = a * b;
+
+      return std::make_pair(
+          (const float_type&)pf,
+          (
+              ((a_split.first * b_split.first) - (const float_type&)pf) + (a_split.first * b_split.second) + (a_split.second * b_split.first)) +
+              (a_split.second * b_split.second));
+   }
+
+   static void normalize(float_pair& p, bool fast = true)
+   {
+      // Converts a pair of floats to standard form
+      //BOOST_ASSERT(std::isfinite(p.first));
+      p = (fast ? fast_sum(p.first, p.second) : sum(p.first, p.second));
+   }
+
+   static void normalize(float_tuple& t)
+   {
+      using std::get;
+      using std::tie;
+
+      float_tuple s(0, 0, 0, 0);
+
+      tie(get<0>(s), get<3>(t)) = fast_sum(get<2>(t), get<3>(t));
+      tie(get<0>(s), get<2>(t)) = fast_sum(get<1>(t), get<0>(s));
+      tie(get<0>(t), get<1>(t)) = fast_sum(get<0>(t), get<0>(s));
+
+      tie(get<0>(s), get<1>(s)) = std::make_tuple(get<0>(t), get<1>(t));
+
+      if (get<1>(s) != 0)
+      {
+         tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<2>(t));
+
+         if (get<2>(s) != 0)
+            tie(get<2>(s), get<3>(s)) = fast_sum(get<2>(s), get<3>(t));
+         else
+            tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<3>(t));
+      }
+      else
+      {
+         tie(get<0>(s), get<1>(s)) = fast_sum(get<0>(s), get<2>(t));
+         if (get<1>(s) != 0)
+            tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<3>(t));
+         else
+            tie(get<0>(s), get<1>(s)) = fast_sum(get<0>(s), get<3>(t));
+      }
+
+      t = s;
+   }
+
+   static void normalize(float_tuple& t, float_type e)
+   {
+     using std::tie;
+     using std::get;
+
+      float_tuple s(0, 0, 0, 0);
+
+      tie(get<0>(s), e)         = fast_sum(get<3>(t), e);
+      tie(get<0>(s), get<3>(t)) = fast_sum(get<2>(t), get<0>(s));
+      tie(get<0>(s), get<2>(t)) = fast_sum(get<1>(t), get<0>(s));
+      tie(get<0>(t), get<1>(t)) = fast_sum(get<0>(t), get<0>(s));
+
+      tie(get<0>(s), get<1>(s)) = std::make_tuple(get<0>(t), get<1>(t));
+
+      if (get<1>(s) != 0)
+      {
+         tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<2>(t));
+         if (get<2>(s) != 0)
+         {
+            tie(get<2>(s), get<3>(s)) = fast_sum(get<2>(s), get<3>(t));
+            if (get<3>(s) != 0)
+               get<3>(s) += e;
+               else tie(get<2>(s), get<3>(s)) = fast_sum(get<2>(s), e);
+         }
+         else
+         {
+            tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<3>(t));
+            if (get<2>(s) != 0)
+               tie(get<2>(s), get<3>(s)) = fast_sum(get<2>(s), e);
+            else
+               tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), e);
+         }
+      }
+      else
+      {
+         tie(get<0>(s), get<1>(s)) = fast_sum(get<0>(s), get<2>(t));
+         if (get<1>(s) != 0)
+         {
+            tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), get<3>(t));
+            if (get<2>(s) != 0)
+               tie(get<2>(s), get<3>(s)) = fast_sum(get<2>(s), e);
+            else
+               tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), e);
+         }
+         else
+         {
+            tie(get<0>(s), get<1>(s)) = fast_sum(get<0>(s), get<3>(t));
+            if (get<1>(s) != 0)
+               tie(get<1>(s), get<2>(s)) = fast_sum(get<1>(s), e);
+            else
+               tie(get<0>(s), get<1>(s)) = fast_sum(get<0>(s), e);
+         }
+      }
+
+      t  = s;
+   }
+};
+
+} // namespace detail
+
 // A cpp_double_float is represented by an unevaluated sum of two floating-point
 // units (say a0 and a1) which satisfy |a1| <= (1 / 2) * ulp(a0).
 // The type of the floating-point constituents should adhere to IEEE754.
@@ -160,6 +372,7 @@ class cpp_double_float
  public:
    using float_type = FloatingPointType;
    using rep_type   = std::pair<float_type, float_type>;
+   using arithmetic = detail::exact_arithmetic<float_type>;
 
   using   signed_types = std::tuple<  signed char,   signed short,   signed int,   signed long,   signed long long, std::intmax_t>;
   using unsigned_types = std::tuple<unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long, std::uintmax_t>;
@@ -284,6 +497,8 @@ class cpp_double_float
    {
       data.first  = -data.first;
       data.second = -data.second;
+
+      arithmetic::normalize(data);
    }
 
    // Getters/Setters
@@ -323,27 +538,27 @@ class cpp_double_float
    // Non-member add/sub/mul/div with constituent type.
    friend inline cpp_double_float operator+(const cpp_double_float& a, const float_type& b)
    {
-      rep_type s = exact_sum(a.first(), b);
+      rep_type s = arithmetic::sum(a.first(), b);
 
       s.second += a.second();
-      normalize_pair(s);
+      arithmetic::normalize(s);
 
       return cpp_double_float(s);
    }
 
    friend inline cpp_double_float operator-(const cpp_double_float& a, const float_type& b)
    {
-      rep_type s = exact_difference(a.first(), b);
+      rep_type s = arithmetic::difference(a.first(), b);
 
       s.second += a.second();
-      normalize_pair(s);
+      arithmetic::normalize(s);
 
       return cpp_double_float(s);
    }
 
    friend inline cpp_double_float operator*(const cpp_double_float& a, const float_type& b)
    {
-      rep_type p = exact_product(a.first(), b);
+      rep_type p = arithmetic::product(a.first(), b);
 
       using std::isfinite;
 
@@ -352,7 +567,7 @@ class cpp_double_float
 
       p.second += a.second() * b;
 
-      normalize_pair(p);
+      arithmetic::normalize(p);
 
       return cpp_double_float(p);
    }
@@ -363,14 +578,14 @@ class cpp_double_float
 
       p.first = a.first() / b;
 
-      q = exact_product(p.first, b);
-      s = exact_difference(a.first(), q.first);
+      q = arithmetic::product(p.first, b);
+      s = arithmetic::difference(a.first(), q.first);
       s.second += a.second();
       s.second -= q.second;
 
       p.second = (s.first + s.second) / b;
 
-      normalize_pair(p);
+      arithmetic::normalize(p);
 
       return cpp_double_float(p);
    }
@@ -384,9 +599,9 @@ class cpp_double_float
    // Unary add/sub/mul/div.
    cpp_double_float& operator+=(const cpp_double_float& other)
    {
-      const rep_type t = exact_sum(second(), other.second());
+      const rep_type t = arithmetic::sum(second(), other.second());
 
-      data = exact_sum(first(),  other.first());
+      data = arithmetic::sum(first(),  other.first());
 
       using std::isfinite;
 
@@ -394,17 +609,17 @@ class cpp_double_float
          return *this;
 
       data.second += t.first;
-      normalize_pair(data);
+      arithmetic::normalize(data);
       data.second += t.second;
-      normalize_pair(data);
+      arithmetic::normalize(data);
 
       return *this;
    }
 
    cpp_double_float& operator-=(const cpp_double_float& other)
    {
-      const rep_type t = exact_difference(second(), other.second());
-      data = exact_difference(first(), other.first());
+      const rep_type t = arithmetic::difference(second(), other.second());
+      data = arithmetic::difference(first(), other.first());
 
       using std::isfinite;
 
@@ -412,17 +627,17 @@ class cpp_double_float
          return *this;
 
       data.second += t.first;
-      normalize_pair(data);
+      arithmetic::normalize(data);
 
       data.second += t.second;
-      normalize_pair(data);
+      arithmetic::normalize(data);
 
       return *this;
    }
 
    cpp_double_float& operator*=(const cpp_double_float& other)
    {
-      rep_type tmp = exact_product(data.first, other.data.first);
+      rep_type tmp = arithmetic::product(data.first, other.data.first);
 
       tmp.second += (  data.first  * other.data.second
                      + data.second * other.data.first);
@@ -454,7 +669,7 @@ class cpp_double_float
 
       const FloatingPointType p_prime = r.first() / other.first();
 
-      normalize_pair(p);
+      arithmetic::normalize(p);
 
       data = p;
 
@@ -504,13 +719,6 @@ class cpp_double_float
       return result;
    }
 
-   static void normalize_pair(rep_type& p, bool fast = true)
-   {
-      // Converts a pair of floats to standard form
-      //BOOST_ASSERT(std::isfinite(p.first));
-      p = (fast ? fast_exact_sum(p.first, p.second) : exact_sum(p.first, p.second));
-   }
-
    void swap(cpp_double_float& other)
    {
       rep_type tmp = data;
@@ -546,102 +754,6 @@ class cpp_double_float
 
  private:
    rep_type data;
-
-   static rep_type split(const float_type& a)
-   {
-      // Split a floating point number in two (high and low) parts approximating the
-      // upper-half and lower-half bits of the float
-      //static_assert(std::numeric_limits<float_type>::is_iec559,
-      //              "double_float<> invoked with non-native floating-point unit");
-
-      // TODO Replace bit shifts with constexpr funcs or ldexpr for better compaitibility
-      constexpr int        MantissaBits   = std::numeric_limits<float_type>::digits;
-      constexpr int        SplitBits      = MantissaBits / 2 + 1;
-      constexpr float_type Splitter       = FloatingPointType((1ULL << SplitBits) + 1);
-      const     float_type SplitThreshold = (std::numeric_limits<float_type>::max)() / (Splitter*2);
-
-      float_type temp, hi, lo;
-
-      // Handle if multiplication with the splitter would cause overflow
-      if (a > SplitThreshold || a < -SplitThreshold)
-      {
-         constexpr float_type Normalizer = float_type(1ULL << (SplitBits + 1));
-
-         const float_type a_ = a / Normalizer;
-
-         temp = Splitter * a_;
-         hi   = temp - (temp - a_);
-         lo   = a_ - hi;
-
-         hi *= Normalizer;
-         lo *= Normalizer;
-      }
-      else
-      {
-         temp = Splitter * a;
-         hi   = temp - (temp - a);
-         lo   = a - hi;
-      }
-
-      return std::make_pair(hi, lo);
-   }
-
-   static rep_type fast_exact_sum(const float_type& a, const float_type& b)
-   {
-      // Exact addition of two floating point numbers, given |a| > |b|
-      using std::fabs;
-      using std::isnormal;
-
-      rep_type out;
-      out.first  = a + b;
-      out.second = b - (out.first - a);
-
-      return out;
-   }
-
-   static rep_type exact_sum(const float_type& a, const float_type& b)
-   {
-      // Exact addition of two floating point numbers
-      rep_type out;
-
-      out.first    = a + b;
-      float_type v = out.first - a;
-      out.second   = (a - (out.first - v)) + (b - v);
-
-      return out;
-   }
-
-   static rep_type exact_difference(const float_type& a, const float_type& b)
-   {
-      // Exact subtraction of two floating point numbers
-      rep_type out;
-
-      out.first    = a - b;
-      float_type v = out.first - a;
-      out.second   = (a - (out.first - v)) - (b + v);
-
-      return out;
-   }
-
-   static rep_type exact_product(const float_type& a, const float_type& b)
-   {
-      // Exact product of two floating point numbers
-      const rep_type a_split = split(a);
-      const rep_type b_split = split(b);
-
-      const volatile float_type pf = a * b;
-
-      return std::make_pair
-      (
-         (const float_type&) pf,
-         (
-            ((a_split.first  * b_split.first) - (const float_type&) pf)
-          +  (a_split.first  * b_split.second)
-          +  (a_split.second * b_split.first)
-         )
-         + (a_split.second * b_split.second)
-      );
-   }
 };
 
 template<typename FloatingPointType> inline cpp_double_float<FloatingPointType> operator+(const cpp_double_float<FloatingPointType>& a, const cpp_double_float<FloatingPointType>& b) { return cpp_double_float<FloatingPointType>(a) += b; }
@@ -683,15 +795,11 @@ template<typename FloatingPointType> void eval_divide  (cpp_double_float<Floatin
 
 template<typename FloatingPointType> void eval_fabs(cpp_double_float<FloatingPointType>& result, const cpp_double_float<FloatingPointType>& a)
 {
+   result = a;
+
    if(a.is_neg())
    {
-      result.rep().first  = -a.rep().first;
-      result.rep().second = -a.rep().second;
-   }
-   else
-   {
-      result.rep().first  = a.rep().first;
-      result.rep().second = a.rep().second;
+      result.negate();
    }
 }
 
@@ -716,7 +824,7 @@ void eval_ldexp(cpp_double_float<FloatingPointType>& result, const cpp_double_fl
       ldexp(a.crep().second, v)
    );
 
-   cpp_double_float<FloatingPointType>::normalize_pair(z);
+   cpp_double_float<FloatingPointType>::arithmetic::normalize(z);
 
    result.rep() = z;
 }
@@ -740,7 +848,7 @@ void eval_floor(cpp_double_float<FloatingPointType>& result, const cpp_double_fl
       result.rep().first  = fhi;
       result.rep().second = floor(x.rep().second);
 
-      double_float_type::normalize_pair(result.rep());
+      double_float_type::arithmetic::normalize(result.rep());
    }
 }
 
@@ -1146,13 +1254,13 @@ public:
    static constexpr int max_exponent = std::numeric_limits<FloatingPointType>::max_exponent - base_class_type::digits;
    static constexpr int min_exponent = std::numeric_limits<FloatingPointType>::min_exponent + base_class_type::digits;
 
-   static const     self_type (min)         () noexcept { using std::ldexp; return self_type( ldexp(self_type(1), -min_exponent)); }
-   static const     self_type (max)         () noexcept { using std::ldexp; return self_type( ldexp(base_class_type::max(), -base_class_type::digits)); }
-   static const     self_type  lowest       () noexcept { return self_type(-(max)()); }
-   static const     self_type  epsilon      () noexcept { using std::ldexp; return self_type( ldexp(self_type(1), -digits)); }
+   static constexpr self_type (min)         () noexcept { return self_type( boost::multiprecision::ldexp(self_type(1), -min_exponent)); }
+   static constexpr self_type (max)         () noexcept { return self_type( std::ldexp(base_class_type::max(), -base_class_type::digits)); }
+   static constexpr self_type  lowest       () noexcept { return self_type(-max()); }
+   static constexpr self_type  epsilon      () noexcept { return self_type( boost::multiprecision::ldexp(self_type(1), -digits)); }
    static constexpr self_type  round_error  () noexcept { return self_type( base_class_type::round_error()); } 
-   static const     self_type  denorm_min   () noexcept { return self_type( (min)()); }
-
+   static constexpr self_type  denorm_min   () noexcept { return self_type( min()); }
+   
    static constexpr self_type  infinity     () noexcept { return self_type( base_class_type::infinity()); }
    static constexpr self_type  quiet_NaN    () noexcept { return self_type( base_class_type::quiet_NaN()); }
    static constexpr self_type  signaling_NaN() noexcept { return self_type( base_class_type::signaling_NaN()); }

--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -1254,13 +1254,13 @@ public:
    static constexpr int max_exponent = std::numeric_limits<FloatingPointType>::max_exponent - base_class_type::digits;
    static constexpr int min_exponent = std::numeric_limits<FloatingPointType>::min_exponent + base_class_type::digits;
 
-   static constexpr self_type (min)         () noexcept { return self_type( boost::multiprecision::ldexp(self_type(1), -min_exponent)); }
-   static constexpr self_type (max)         () noexcept { return self_type( std::ldexp(base_class_type::max(), -base_class_type::digits)); }
-   static constexpr self_type  lowest       () noexcept { return self_type(-max()); }
-   static constexpr self_type  epsilon      () noexcept { return self_type( boost::multiprecision::ldexp(self_type(1), -digits)); }
+   static const     self_type (min)         () noexcept { using std::ldexp; return self_type( ldexp(self_type(1), -min_exponent)); }
+   static const     self_type (max)         () noexcept { using std::ldexp; return self_type( ldexp(base_class_type::max(), -base_class_type::digits)); }
+   static const     self_type  lowest       () noexcept { return self_type(-(max)()); }
+   static const     self_type  epsilon      () noexcept { using std::ldexp; return self_type( ldexp(self_type(1), -digits)); }
    static constexpr self_type  round_error  () noexcept { return self_type( base_class_type::round_error()); } 
-   static constexpr self_type  denorm_min   () noexcept { return self_type( min()); }
-   
+   static const     self_type  denorm_min   () noexcept { return self_type( (min)()); }
+
    static constexpr self_type  infinity     () noexcept { return self_type( base_class_type::infinity()); }
    static constexpr self_type  quiet_NaN    () noexcept { return self_type( base_class_type::quiet_NaN()); }
    static constexpr self_type  signaling_NaN() noexcept { return self_type( base_class_type::signaling_NaN()); }

--- a/include/boost/multiprecision/cpp_quad_float.hpp
+++ b/include/boost/multiprecision/cpp_quad_float.hpp
@@ -1,0 +1,671 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2021 Fahad Syed.
+//  Copyright 2021 Christopher Kormanyos.
+//  Copyright 2021 Janek Kozicki.
+//  Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_MP_CPP_QUAD_FLOAT_2021_07_29_HPP
+#define BOOST_MP_CPP_QUAD_FLOAT_2021_07_29_HPP
+
+#include <boost/config.hpp>
+
+#include <type_traits>
+#include <string>
+#include <utility>
+#include <limits>
+#include <sstream>
+#include <tuple>
+#include <vector>
+#include <array>
+
+#include <boost/assert.hpp>
+#include <boost/multiprecision/number.hpp>
+#include <boost/multiprecision/detail/float_string_cvt.hpp>
+#include <boost/multiprecision/detail/hash.hpp>
+#include <boost/multiprecision/cpp_double_float.hpp>
+#include <boost/type_traits/common_type.hpp>
+
+namespace boost { namespace multiprecision { namespace backends {
+
+template <typename FloatingPointType>
+class cpp_quad_float;
+
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator+(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator-(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator*(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator/(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator+(const cpp_quad_float<FloatingPointType>& a, const FloatingPointType& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator-(const cpp_quad_float<FloatingPointType>& a, const FloatingPointType& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator*(const cpp_quad_float<FloatingPointType>& a, const FloatingPointType& b);
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator/(const cpp_quad_float<FloatingPointType>& a, const FloatingPointType& b);
+
+template <typename FloatingPointType>
+inline bool operator<(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline bool operator<=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline bool operator==(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline bool operator!=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline bool operator>=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+template <typename FloatingPointType>
+inline bool operator>(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b);
+
+template <typename FloatingPointType>
+void eval_add(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+template <typename FloatingPointType>
+void eval_subtract(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+template <typename FloatingPointType>
+void eval_multiply(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+template <typename FloatingPointType>
+void eval_divide(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+
+template <typename FloatingPointType>
+void eval_frexp(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& a, int* v);
+template <typename FloatingPointType>
+void eval_ldexp(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& a, int v);
+template <typename FloatingPointType>
+void eval_floor(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+template <typename FloatingPointType>
+void eval_ceil(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x);
+template <typename FloatingPointType>
+void eval_sqrt(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& o);
+template <typename FloatingPointType>
+int eval_fpclassify(const cpp_quad_float<FloatingPointType>& o);
+
+template <typename FloatingPointType,
+          typename R>
+typename std::enable_if<std::is_integral<R>::value == true>::type eval_convert_to(R* result, const cpp_quad_float<FloatingPointType>& backend);
+
+template <typename FloatingPointType,
+          typename R>
+typename std::enable_if<std::is_integral<R>::value == false>::type eval_convert_to(R* result, const cpp_quad_float<FloatingPointType>& backend);
+
+template <typename FloatingPointType,
+          typename char_type,
+          typename traits_type>
+std::basic_ostream<char_type, traits_type>& operator<<(std::basic_ostream<char_type, traits_type>& os,
+                                                       const cpp_quad_float<FloatingPointType>&  f);
+
+template <typename FloatingPointType>
+std::size_t hash_value(const cpp_quad_float<FloatingPointType>& a);
+
+}}} // namespace boost::multiprecision::backends
+
+namespace boost { namespace math {
+
+template <typename FloatingPointType>
+int fpclassify(const boost::multiprecision::backends::cpp_quad_float<FloatingPointType>& o);
+
+}} // namespace boost::math
+
+namespace std {
+
+// Foward declarations of various specializations of std::numeric_limits
+
+template <typename FloatingPointType>
+class numeric_limits<boost::multiprecision::backends::cpp_quad_float<FloatingPointType> >;
+
+template <typename FloatingPointType,
+          const boost::multiprecision::expression_template_option ExpressionTemplatesOption>
+class numeric_limits<boost::multiprecision::number<boost::multiprecision::backends::cpp_quad_float<FloatingPointType>, ExpressionTemplatesOption> >;
+
+} // namespace std
+
+namespace boost { namespace multiprecision {
+
+template <typename FloatingPointType>
+struct number_category<backends::cpp_quad_float<FloatingPointType> >
+    : public std::integral_constant<int, number_kind_floating_point>
+{};
+
+namespace backends {
+
+// A cpp_quad_float is represented by an unevaluated sum of four floating-point
+// units (say a[0...n]) which satisfy |a[i+1]| <= (1 / 2) * ulp(a[i]).
+// The type of the floating-point constituents should adhere to IEEE754.
+
+template <typename FloatingPointType>
+class cpp_quad_float
+{
+ public:
+   using float_type = FloatingPointType;
+   using rep_type   = std::tuple<float_type, float_type, float_type, float_type>;
+   using float_pair = typename detail::exact_arithmetic<float_type>::float_pair;
+   using arithmetic = detail::exact_arithmetic<float_type>;
+
+   using signed_types   = std::tuple<signed char, signed short, signed int, signed long, signed long long, std::intmax_t>;
+   using unsigned_types = std::tuple<unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long, std::uintmax_t>;
+   using float_types    = std::tuple<float, double, long double>;
+   using exponent_type  = int;
+
+   // Default constructor.
+   cpp_quad_float() {}
+
+   // Copy constructor.
+   constexpr cpp_quad_float(const cpp_quad_float&) = default;
+
+   // Constructors from other floating-point types.
+   template <typename FloatType,
+             typename std::enable_if<(detail::is_floating_point_or_float128<FloatType>::value == true) && (std::numeric_limits<FloatType>::digits <= std::numeric_limits<float_type>::digits)>::type const* = nullptr>
+   constexpr cpp_quad_float(const FloatType& f) : data(std::make_tuple(f, (float_type)0, (float_type)0, (float_type)0)) {}
+
+   constexpr cpp_quad_float(const rep_type& r) : data(r) {}
+
+   //template <typename FloatType,
+   //          typename std::enable_if<((std::numeric_limits<FloatType>::is_iec559 == true) && (std::numeric_limits<FloatType>::digits > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
+   //constexpr cpp_quad_float(const FloatType& f)
+   //    : data(std::make_pair(static_cast<float_type>(f),
+   //                          static_cast<float_type>(f - (FloatType) static_cast<float_type>(f)))) {}
+
+   // Constructor from other cpp_quad_float<> objects.
+   //template <typename OtherFloatType,
+   //          typename std::enable_if<((std::is_floating_point<OtherFloatType>::value == true) && (std::is_same<FloatingPointType, OtherFloatType>::value == false))>::type const* = nullptr>
+   //cpp_quad_float(const cpp_quad_float<OtherFloatType>& a)
+   //    : cpp_quad_float(a.first())
+   //{
+   //   *this += a.second();
+   //}
+
+   // Constructors from integers
+   //template <typename IntegralType,
+   //          typename std::enable_if<((std::is_integral<IntegralType>::value == true) && (std::numeric_limits<IntegralType>::digits <= std::numeric_limits<FloatingPointType>::digits))>::type const* = nullptr>
+   //constexpr cpp_quad_float(const IntegralType& f) : data(std::make_pair(static_cast<float_type>(f), (float_type)0)) {}
+
+   // Constructors from integers which hold more information than *this can contain
+   //template <typename UnsignedIntegralType,
+   //          typename std::enable_if<((std::is_integral<UnsignedIntegralType>::value == true) && (std::is_unsigned<UnsignedIntegralType>::value == true) && (std::numeric_limits<UnsignedIntegralType>::digits > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
+   //cpp_quad_float(UnsignedIntegralType u)
+
+   //template <typename SignedIntegralType,
+   //          typename std::enable_if<((std::is_integral<SignedIntegralType>::value == true) && (std::is_signed<SignedIntegralType>::value == true) && (std::numeric_limits<SignedIntegralType>::digits + 1 > std::numeric_limits<float_type>::digits))>::type const* = nullptr>
+   //cpp_quad_float(SignedIntegralType n) : cpp_quad_float(static_cast<typename std::make_unsigned<SignedIntegralType>::type>(std::abs(n)))
+   //{
+   //   if (n < 0)
+   //      *this = -*this;
+   //}
+
+   //constexpr cpp_quad_float(const float_type& a, const float_type& b) : data(std::make_pair(a, b)) {}
+   //constexpr cpp_quad_float(const std::pair<float_type, float_type>& p) : data(p) {}
+
+   cpp_quad_float(const std::string& str)
+   {
+      boost::multiprecision::detail::convert_from_string(*this, str.c_str());
+   }
+
+   cpp_quad_float(const char* pstr)
+   {
+      boost::multiprecision::detail::convert_from_string(*this, pstr);
+   }
+
+   constexpr cpp_quad_float(cpp_quad_float&&) = default;
+
+   ~cpp_quad_float() = default;
+
+   std::size_t hash() const
+   {
+      // Here we first convert to scientific string, then
+      // hash the charactgers in the scientific string.
+      // TBD: Is there a faster or more simple hash method?
+
+      const std::string str_to_hash = str(std::numeric_limits<cpp_quad_float>::digits10, std::ios::scientific);
+
+      std::size_t result = 0;
+
+      for (std::string::size_type i = 0U; i < str_to_hash.length(); ++i)
+         boost::multiprecision::detail::hash_combine(result, str_to_hash.at(i));
+
+      return result;
+   }
+
+   // Casts
+//   operator signed char() const { return (signed char)data.first; }
+//   operator signed short() const { return (signed short)data.first; }
+//   operator signed int() const { return (signed int)data.first + (signed int)data.second; }
+//   operator signed long() const { return (signed long)data.first + (signed long)data.second; }
+//   operator signed long long() const { return (signed long long)data.first + (signed long long)data.second; }
+//   operator unsigned char() const { return (unsigned char)data.first; }
+//   operator unsigned short() const { return (unsigned short)data.first; }
+//   operator unsigned int() const { return (unsigned int)((unsigned int)data.first + (signed int)data.second); }
+//   operator unsigned long() const { return (unsigned long)((unsigned long)data.first + (signed long)data.second); }
+//   operator unsigned long long() const { return (unsigned long long)((unsigned long long)data.first + (signed long long)data.second); }
+//   operator float() const { return (float)data.first + (float)data.second; }
+//   operator double() const { return (double)data.first + (double)data.second; }
+//   operator long double() const { return (long double)data.first + (long double)data.second; }
+//#ifdef BOOST_MATH_USE_FLOAT128
+//   explicit operator boost::multiprecision::float128() const
+//   {
+//      return static_cast<boost::multiprecision::float128>(data.first) + static_cast<boost::multiprecision::float128>(data.second);
+//   }
+//#endif
+
+   // Methods
+   constexpr cpp_quad_float<float_type> negative() const
+   {
+     using std::get;
+     return cpp_quad_float<float_type>(std::make_tuple(-get<0>(data), -get<1>(data), -get<2>(data), -get<3>(data)));
+   }
+
+   constexpr bool                       is_negative() const { return data.first < 0; }
+
+   //void negate()
+   //{
+   //   data.first  = -data.first;
+   //   data.second = -data.second;
+
+   //   normalize_pair(data);
+   //}
+
+   // Getters/Setters
+   //constexpr const float_type& first() const { return data.first; }
+   //constexpr const float_type& second() const { return data.second; }
+
+   rep_type&       rep() { return data; }
+   const rep_type& rep() const { return data; }
+   const rep_type& crep() const { return data; }
+
+   // Retrieve debug string.
+   //std::string get_raw_str() const
+   //{
+   //   std::stringstream ss;
+   //   ss << std::hexfloat << data.first << " + " << std::hexfloat << data.second;
+   //   return ss.str();
+   //}
+
+   // Assignment operators.
+   cpp_quad_float& operator=(const cpp_quad_float&) = default;
+
+   cpp_quad_float& operator=(cpp_quad_float&&) = default;
+
+   // Non-member add/sub/mul/div with constituent type.
+   //friend inline cpp_quad_float operator+(const cpp_quad_float& a, const float_type& b)
+   //{
+   //}
+
+   //friend inline cpp_quad_float operator-(const cpp_quad_float& a, const float_type& b)
+   //{
+   //}
+
+   //friend inline cpp_quad_float operator*(const cpp_quad_float& a, const float_type& b)
+   //{
+   //}
+
+   //friend inline cpp_quad_float operator/(const cpp_quad_float& a, const float_type& b)
+   //{
+   //}
+
+   // Unary add/sub/mul/div with constituent part.
+   cpp_quad_float& operator+=(const float_type& a)
+   {
+      *this = *this + a;
+      return *this;
+   }
+   cpp_quad_float& operator-=(const float_type& a)
+   {
+      *this = *this - a;
+      return *this;
+   }
+   cpp_quad_float& operator*=(const float_type& a)
+   {
+      *this = *this * a;
+      return *this;
+   }
+   cpp_quad_float& operator/=(const float_type& a)
+   {
+      *this = *this / a;
+      return *this;
+   }
+
+   // Unary add/sub/mul/div.
+   cpp_quad_float& operator+=(const cpp_quad_float& other)
+   {
+      using std::array;
+      using std::fabs;
+      using std::get;
+      using std::tie;
+
+      float_pair u, v;
+      int        i, j, k;
+      i = j = k = 0;
+
+      array<float_type, 4> a = {get<0>(this->data), get<1>(this->data), get<2>(this->data), get<3>(this->data)};
+      array<float_type, 4> b = {get<0>(other.data), get<1>(other.data), get<2>(other.data), get<3>(other.data)};
+      array<float_type, 4> s = {};
+
+      if (fabs(a[i]) > fabs(b[j]))
+         v.first = a[i++];
+      else
+         v.first = b[j++];
+      if (fabs(a[i]) > fabs(b[j]))
+         v.second = a[i++];
+      else
+         v.second = b[j++];
+
+      arithmetic::normalize(v);
+
+      while (k < 4)
+      {
+         if (i >= 4 && j >= 4)
+         {
+            s[k] = v.first;
+            if (k < 3)
+               s[++k] = v.second;
+            break;
+         }
+
+         if (i >= 4)
+            u.second = b[j++];
+         else if (j >= 4)
+            u.second = a[i++];
+         else if (fabs(a[i]) > fabs(b[j]))
+            u.second = a[i++];
+         else
+            u.second = b[j++];
+
+         tie(u.first, v.second) = arithmetic::sum(v.second, u.second);
+
+         // TODO try fast_sum
+         tie(u.first, v.first) = arithmetic::sum(u.first, v.first);
+
+         // TODO can the conditions be simplified further?
+         if (v.first == 0 || v.second == 0)
+         {
+            if (v.second == 0)
+            {
+               v.second = v.first;
+               v.first  = u.first;
+            }
+            else
+               v.first = u.first;
+
+            u.first = 0;
+         }
+
+         if (u.first != 0)
+            s[k++] = u.first;
+      }
+
+      // Add the rest
+      for (k = i; k < 4; k++)
+         s[3] += a[k];
+      for (k = j; k < 4; k++)
+         s[3] += b[k];
+
+      data = std::make_tuple(s[0], s[1], s[2], s[3]);
+      arithmetic::normalize(data);
+
+      return *this;
+   }
+
+   cpp_quad_float& operator-=(const cpp_quad_float& other)
+   {
+      *this += -other;
+      return *this;
+   }
+
+   cpp_quad_float& operator*=(const cpp_quad_float& other)
+   {
+   }
+
+   cpp_quad_float& operator/=(const cpp_quad_float& other)
+   {
+   }
+
+   cpp_quad_float operator++(int)
+   {
+      cpp_quad_float t(*this);
+      ++*this;
+      return t;
+   }
+   cpp_quad_float operator--(int)
+   {
+      cpp_quad_float t(*this);
+      --*this;
+      return t;
+   }
+   cpp_quad_float& operator++() { return *this += cpp_quad_float<float_type>(float_type(1.0F)); }
+   cpp_quad_float& operator--() { return *this -= cpp_quad_float<float_type>(float_type(1.0F)); }
+
+   cpp_quad_float operator-() const { return negative(); }
+
+   // Helper functions
+   static cpp_quad_float<float_type> pow10(int p)
+   {
+      using local_float_type = cpp_quad_float;
+
+      local_float_type result;
+
+      if (p < 0)
+         result = local_float_type(1U) / pow10(-p);
+      else if (p == 0)
+         result = local_float_type(1U);
+      else if (p == 1)
+         result = local_float_type(10U);
+      else if (p == 2)
+         result = local_float_type(100U);
+      else if (p == 3)
+         result = local_float_type(1000U);
+      else if (p == 4)
+         result = local_float_type(10000U);
+      else
+      {
+         result = local_float_type(1U);
+
+         local_float_type y(10U);
+
+         std::uint32_t p_local = (std::uint32_t)p;
+
+         for (;;)
+         {
+            if (std::uint_fast8_t(p_local & 1U) != 0U)
+            {
+               result *= y;
+            }
+
+            p_local >>= 1U;
+
+            if (p_local == 0U)
+            {
+               break;
+            }
+            else
+            {
+               y *= y;
+            }
+         }
+      }
+
+      return result;
+   }
+
+   void swap(cpp_quad_float& other)
+   {
+      rep_type tmp = data;
+
+      data = other.data;
+
+      other.data = tmp;
+   }
+
+   //int compare(const cpp_quad_float& other) const
+   //{
+   //}
+
+   std::string str(std::streamsize number_of_digits, const std::ios::fmtflags format_flags) const
+   {
+      if (number_of_digits == 0)
+         number_of_digits = std::numeric_limits<cpp_quad_float>::digits10;
+
+      const std::string my_str = boost::multiprecision::detail::convert_to_string(*this, number_of_digits, format_flags);
+
+      return my_str;
+   }
+
+   // Debugging
+   std::string raw_str() const
+   {
+      using std::get;
+
+      std::stringstream ss;
+
+      ss << std::hexfloat;
+      ss << get<0>(data) << " + " << get<1>(data) << " + " << get<2>(data) << " + " << get<3>(data);
+      ss << std::endl;
+
+      return ss.str();
+   }
+
+ private:
+   rep_type data;
+
+};
+
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator+(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return cpp_quad_float<FloatingPointType>(a) += b; }
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator-(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return cpp_quad_float<FloatingPointType>(a) -= b; }
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator*(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return cpp_quad_float<FloatingPointType>(a) *= b; }
+template <typename FloatingPointType>
+inline cpp_quad_float<FloatingPointType> operator/(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return cpp_quad_float<FloatingPointType>(a) /= b; }
+
+template <typename FloatingPointType>
+inline bool operator<(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) < 0); }
+template <typename FloatingPointType>
+inline bool operator<=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) <= 0); }
+template <typename FloatingPointType>
+inline bool operator==(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) == 0); }
+template <typename FloatingPointType>
+inline bool operator!=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) != 0); }
+template <typename FloatingPointType>
+inline bool operator>=(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) >= 0); }
+template <typename FloatingPointType>
+inline bool operator>(const cpp_quad_float<FloatingPointType>& a, const cpp_quad_float<FloatingPointType>& b) { return (a.compare(b) > 0); }
+
+// -- Input/Output Streaming
+template <typename FloatingPointType, typename char_type, typename traits_type>
+std::basic_ostream<char_type, traits_type>&
+operator<<(std::basic_ostream<char_type, traits_type>& os, const cpp_quad_float<FloatingPointType>& f)
+{
+   const std::string str_result = f.str(os.precision(), os.flags());
+
+   return (os << str_result);
+}
+
+template <typename FloatingPointType, typename char_type, typename traits_type>
+std::basic_istream<char_type, traits_type>&
+operator>>(std::basic_istream<char_type, traits_type>& is, cpp_quad_float<FloatingPointType>& f)
+{
+   std::string str;
+   is >> str;
+   boost::multiprecision::detail::convert_from_string(f, str.c_str());
+   return is;
+}
+
+template <typename FloatingPointType>
+void eval_add(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x) { result += x; }
+template <typename FloatingPointType>
+void eval_subtract(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x) { result -= x; }
+template <typename FloatingPointType>
+void eval_multiply(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x) { result *= x; }
+template <typename FloatingPointType>
+void eval_divide(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x) { result /= x; }
+
+template <typename FloatingPointType>
+void eval_frexp(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& a, int* v)
+{
+}
+
+template <typename FloatingPointType>
+void eval_ldexp(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& a, int v)
+{
+}
+
+template <typename FloatingPointType>
+void eval_floor(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x)
+{
+}
+
+template <typename FloatingPointType>
+void eval_ceil(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& x)
+{
+}
+
+template <typename FloatingPointType>
+void eval_sqrt(cpp_quad_float<FloatingPointType>& result, const cpp_quad_float<FloatingPointType>& o)
+{
+}
+
+template <typename FloatingPointType>
+int eval_fpclassify(const cpp_quad_float<FloatingPointType>& o)
+{
+   return (int)(boost::math::fpclassify)(o.crep().first);
+}
+
+template <typename FloatingPointType,
+          typename R>
+typename std::enable_if<std::is_integral<R>::value == true>::type eval_convert_to(R* result, const cpp_quad_float<FloatingPointType>& backend)
+{
+   // TBD: Does boost::common_type have a C++ 11 replacement?
+   using c_type = typename boost::common_type<R, FloatingPointType>::type;
+
+   using std::fabs;
+
+   BOOST_CONSTEXPR const c_type my_max = static_cast<c_type>((std::numeric_limits<R>::max)());
+   BOOST_CONSTEXPR const c_type my_min = static_cast<c_type>((std::numeric_limits<R>::min)());
+   c_type                       ct     = fabs(backend.crep().first);
+
+   (void)my_min;
+
+   if (ct > my_max)
+      if (!std::is_unsigned<R>::value)
+         *result = backend.crep().first >= typename cpp_quad_float<FloatingPointType>::float_type(0U) ? (std::numeric_limits<R>::max)() : detail::minus_max<R>();
+      else
+         *result = (std::numeric_limits<R>::max)();
+   else
+   {
+     // TODO
+   }
+}
+
+template <typename FloatingPointType,
+          typename R>
+typename std::enable_if<std::is_integral<R>::value == false>::type eval_convert_to(R* result, const cpp_quad_float<FloatingPointType>& backend)
+{
+}
+
+template <typename FloatingPointType>
+std::size_t hash_value(const cpp_quad_float<FloatingPointType>& a)
+{
+   return a.hash();
+}
+
+} // namespace backends
+}} // namespace boost::multiprecision
+
+namespace boost { namespace math {
+
+template <typename FloatingPointType>
+int fpclassify(const boost::multiprecision::backends::cpp_quad_float<FloatingPointType>& o)
+{
+   using std::fpclassify;
+
+   return (int)(fpclassify)(o.crep().first);
+}
+
+}} // namespace boost::math
+
+#endif // BOOST_MP_CPP_QUAD_FLOAT_2021_07_29_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -129,6 +129,17 @@ test-suite df_qf_tests :
 
 ;
 
+test-suite df_qf_quadmath_tests :
+
+   [ run test_arithmetic_df.cpp no_eh_support quadmath : : : <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_cpp_double_float_arithmetic.cpp quadmath no_eh_support : : : <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_sqrt.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_exp.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_log.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_sin.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
+
+;
+
 test-suite arithmetic_tests :
 
    [ run test_arithmetic_backend_concept.cpp no_eh_support ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -132,6 +132,10 @@ test-suite df_qf_tests :
 test-suite df_qf_quadmath_tests :
 
    [ run test_arithmetic_df.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
+   [ run test_sqrt.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
+   [ run test_exp.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
+   [ run test_log.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
+   [ run test_sin.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
 
 ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -131,12 +131,7 @@ test-suite df_qf_tests :
 
 test-suite df_qf_quadmath_tests :
 
-   [ run test_arithmetic_df.cpp no_eh_support quadmath : : : <define>BOOST_MATH_USE_FLOAT128 release : ]
-   [ run test_cpp_double_float_arithmetic.cpp quadmath no_eh_support : : : <define>BOOST_MATH_USE_FLOAT128 release : ]
-   [ run test_sqrt.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
-   [ run test_exp.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
-   [ run test_log.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
-   [ run test_sin.cpp no_eh_support quadmath : : : <define>TEST_CPP_DOUBLE_FLOAT <define>BOOST_MATH_USE_FLOAT128 release : ]
+   [ run test_arithmetic_df.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : : <build>no ] ]
 
 ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -131,7 +131,7 @@ test-suite df_qf_tests :
 
 test-suite df_qf_quadmath_tests :
 
-   [ run test_arithmetic_df.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : : <build>no ] ]
+   [ run test_arithmetic_df.cpp quadmath no_eh_support : : : [ check-target-builds ../config//has_float128 : <define>BOOST_MATH_USE_FLOAT128 : <build>no ] ]
 
 ;
 

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -58,7 +58,6 @@ struct control
 
    static std::mt19937       engine_man;
    static std::ranlux24_base engine_sgn;
-   static random_engine_type engine_dec_pt;
 
    template<const std::size_t DigitsToGet = digits10>
    static void get_random_fixed_string(std::string& str, const bool is_unsigned = false)
@@ -127,7 +126,7 @@ struct control
       dist_exp
       (
          0,
-         unsigned(float(max_exponent10) * 0.15F)
+         std::numeric_limits<ConstituentFloatType>::digits10 < 10 ? 15 : 85
       );
 
       std::string str_exp = ((exp_is_neg == false) ? "E+" :  "E-");
@@ -151,7 +150,6 @@ template<typename ConstituentFloatType> constexpr int control<ConstituentFloatTy
 
 template<typename ConstituentFloatType> std::mt19937       control<ConstituentFloatType>::engine_man(static_cast<typename std::mt19937::result_type>(std::clock()));
 template<typename ConstituentFloatType> std::ranlux24_base control<ConstituentFloatType>::engine_sgn(static_cast<typename std::ranlux24_base::result_type>(std::clock()));
-template<typename ConstituentFloatType> typename control<ConstituentFloatType>::random_engine_type control<ConstituentFloatType>::engine_dec_pt(static_cast<typename random_engine_type::result_type>(std::clock()));
 
 template <typename ConstituentFloatType>
 bool test_op(char op, const unsigned count = 10000U)
@@ -160,7 +158,7 @@ bool test_op(char op, const unsigned count = 10000U)
    using double_float_type  = typename control<float_type>::double_float_type;
    using control_float_type = typename control<float_type>::control_float_type;
 
-   const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<double_float_type>::digits + 2);
+   const control_float_type MaxError = ldexp(control_float_type(1), -std::numeric_limits<double_float_type>::digits + 2);
    std::cout << "testing operator" << op << " (accuracy = " << std::numeric_limits<double_float_type>::digits << " bits)...";
 
    for (unsigned i = 0U; i < count; ++i)
@@ -174,25 +172,12 @@ bool test_op(char op, const unsigned count = 10000U)
       const double_float_type  df_a(str_a);
       const double_float_type  df_b(str_b);
 
-      #if 0
-      const control_float_type ctrl_a =   control_float_type(double_float_type::canonical_value(df_a).crep().first.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().first.crep().second)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().second.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().second.crep().second)
-                                        ;
-      const control_float_type ctrl_b =   control_float_type(double_float_type::canonical_value(df_b).crep().first.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_b).crep().first.crep().second)
-                                        + control_float_type(double_float_type::canonical_value(df_b).crep().second.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_b).crep().second.crep().second)
-                                        ;
-      #else
       const control_float_type ctrl_a =   control_float_type(double_float_type::canonical_value(df_a).crep().first)
                                         + control_float_type(double_float_type::canonical_value(df_a).crep().second)
                                         ;
       const control_float_type ctrl_b =   control_float_type(double_float_type::canonical_value(df_b).crep().first)
                                         + control_float_type(double_float_type::canonical_value(df_b).crep().second)
                                         ;
-      #endif
 
       double_float_type  df_c;
       control_float_type ctrl_c;
@@ -225,24 +210,28 @@ bool test_op(char op, const unsigned count = 10000U)
          break;
       }
 
-      #if 0
-      const control_float_type ctrl_df_c =   control_float_type(double_float_type::canonical_value(df_c).crep().first.crep().first)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().first.crep().second)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().second.crep().first)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().second.crep().second)
-                                           ;
-      #else
       const control_float_type ctrl_df_c =   control_float_type(double_float_type::canonical_value(df_c).crep().first)
                                            + control_float_type(double_float_type::canonical_value(df_c).crep().second)
                                            ;
-      #endif
 
       const control_float_type delta = fabs(1 - fabs(ctrl_c / ctrl_df_c));
 
       if (delta > MaxError)
       {
-         std::cerr << std::setprecision(std::numeric_limits<double_float_type>::digits10 + 2);
-         std::cerr << " [FAILED] while performing '" << std::setprecision(100000) << ctrl_a << "' " << op << " '" << ctrl_b << "', got incorrect result: " << (df_c) << std::endl;
+         std::cout << std::setprecision(std::numeric_limits<double_float_type>::digits10 + 2);
+         std::cout << " [FAILED] while performing '"
+                   << std::setprecision(std::numeric_limits<double_float_type>::max_digits10)
+                   << df_a
+                   << "' "
+                   << op
+                   << " '"
+                   << df_b
+                   << std::endl
+                   << "got incorrect result: "
+                   << df_c
+                   << ", correct result is: "
+                   << ctrl_df_c
+                   << std::endl;
 
          return false;
       }
@@ -260,7 +249,8 @@ bool test_sqrt(const unsigned count = 10000U)
    using double_float_type  = typename control<float_type>::double_float_type;
    using control_float_type = typename control<float_type>::control_float_type;
 
-   const control_float_type MaxError = boost::multiprecision::ldexp(control_float_type(1), -std::numeric_limits<double_float_type>::digits + 2);
+   const control_float_type MaxError = ldexp(control_float_type(1), -std::numeric_limits<double_float_type>::digits + 2);
+
    std::cout << "testing func sqrt (accuracy = " << std::numeric_limits<double_float_type>::digits << " bits)...";
 
    for (unsigned i = 0U; i < count; ++i)
@@ -271,17 +261,9 @@ bool test_sqrt(const unsigned count = 10000U)
 
       const double_float_type  df_a(str_a);
 
-      #if 0
-      const control_float_type ctrl_a =   control_float_type(double_float_type::canonical_value(df_a).crep().first.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().first.crep().second)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().second.crep().first)
-                                        + control_float_type(double_float_type::canonical_value(df_a).crep().second.crep().second)
-                                        ;
-      #else
       const control_float_type ctrl_a =   control_float_type(double_float_type::canonical_value(df_a).crep().first)
                                         + control_float_type(double_float_type::canonical_value(df_a).crep().second)
                                         ;
-      #endif
 
       double_float_type  df_c;
       control_float_type ctrl_c;
@@ -289,24 +271,16 @@ bool test_sqrt(const unsigned count = 10000U)
       df_c   = sqrt(df_a);
       ctrl_c = sqrt(ctrl_a);
 
-      #if 0
-      const control_float_type ctrl_df_c =   control_float_type(double_float_type::canonical_value(df_c).crep().first.crep().first)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().first.crep().second)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().second.crep().first)
-                                           + control_float_type(double_float_type::canonical_value(df_c).crep().second.crep().second)
-                                           ;
-      #else
       const control_float_type ctrl_df_c =   control_float_type(double_float_type::canonical_value(df_c).crep().first)
                                            + control_float_type(double_float_type::canonical_value(df_c).crep().second)
                                            ;
-      #endif
 
       const control_float_type delta = fabs(1 - fabs(ctrl_c / ctrl_df_c));
 
       if (delta > MaxError)
       {
          std::cerr << std::setprecision(std::numeric_limits<double_float_type>::digits10 + 2);
-         std::cerr << " [FAILED] while performing '" << std::setprecision(100000) << ctrl_a << "' sqrt', got incorrect result: " << (df_c) << std::endl;
+         std::cerr << " [FAILED] while performing '" << std::setprecision(std::numeric_limits<double_float_type>::max_digits10) << ctrl_a << "' sqrt', got incorrect result: " << (df_c) << std::endl;
 
          return false;
       }
@@ -353,9 +327,9 @@ int main()
    constexpr unsigned int test_cases_float128 = 20000U;
    #endif
 
-   result_is_ok &= local::test_arithmetic<float>(test_cases_built_in);
-   result_is_ok &= local::test_arithmetic<double>(test_cases_built_in);
-   //result_is_ok &= local::test_arithmetic<long double>(test_cases_built_in);
+   result_is_ok &= local::test_arithmetic<float>(test_cases_built_in / 4);
+   result_is_ok &= local::test_arithmetic<double>(test_cases_built_in * 2);
+   result_is_ok &= local::test_arithmetic<long double>(test_cases_built_in * 5);
 #ifdef BOOST_MATH_USE_FLOAT128
    result_is_ok &= local::test_arithmetic<boost::multiprecision::float128>(test_cases_float128);
 #else

--- a/test/test_cpp_double_float_arithmetic.cpp
+++ b/test/test_cpp_double_float_arithmetic.cpp
@@ -316,20 +316,20 @@ int main()
    bool result_is_ok = true;
 
    #if defined(CPP_DOUBLE_FLOAT_REDUCE_TEST_DEPTH)
-   constexpr unsigned int test_cases_built_in = 10000U;
+   constexpr unsigned int test_cases_built_in = 5000U;
    #else
-   constexpr unsigned int test_cases_built_in = 1000000U;
+   constexpr unsigned int test_cases_built_in = 50000U;
    #endif
 
    #if defined(CPP_DOUBLE_FLOAT_REDUCE_TEST_DEPTH)
    constexpr unsigned int test_cases_float128 = 1000U;
    #else
-   constexpr unsigned int test_cases_float128 = 20000U;
+   constexpr unsigned int test_cases_float128 = 10000U;
    #endif
 
-   result_is_ok &= local::test_arithmetic<float>(test_cases_built_in / 4);
-   result_is_ok &= local::test_arithmetic<double>(test_cases_built_in * 2);
-   result_is_ok &= local::test_arithmetic<long double>(test_cases_built_in * 5);
+   result_is_ok &= local::test_arithmetic<float>(test_cases_built_in);
+   result_is_ok &= local::test_arithmetic<double>(test_cases_built_in);
+   result_is_ok &= local::test_arithmetic<long double>(test_cases_built_in);
 #ifdef BOOST_MATH_USE_FLOAT128
    result_is_ok &= local::test_arithmetic<boost::multiprecision::float128>(test_cases_float128);
 #else


### PR DESCRIPTION
Corrects random generator over/under sized exponents for `long``double` and also adds a few more quadmath tests for `cpp_double_float<boost::multiprecision::float128>`.