### PR TITLE
check if integer width is adequate in split()

### DIFF
--- a/include/boost/multiprecision/cpp_double_float.hpp
+++ b/include/boost/multiprecision/cpp_double_float.hpp
@@ -214,7 +214,15 @@ struct exact_arithmetic
       // TODO Replace bit shifts with constexpr funcs or ldexp for better compaitibility
       constexpr int        MantissaBits   = std::numeric_limits<float_type>::digits;
       constexpr int        SplitBits      = MantissaBits / 2 + 1;
-      constexpr float_type Splitter       = FloatingPointType((1ULL << SplitBits) + 1);
+      
+      // Check if the integer is wide enough to hold the Splitter.
+      static_assert(std::numeric_limits<uintmax_t>::digits > SplitBits,
+        "Inadequate integer width for binary shifting needed in split(), try using ldexp instead");
+      // If the above line gives an compilation error, replace the
+      // line below it with the commented line
+
+      constexpr    float_type Splitter    = FloatingPointType((uintmax_t(1) << SplitBits) + 1);
+    //static const float_type Splitter    = std::ldexp(FloatingPointType(1), SplitBits) + 1;
       const float_type     SplitThreshold = (std::numeric_limits<float_type>::max)() / (Splitter * 2);
 
       float_type temp, hi, lo;

--- a/include/boost/multiprecision/cpp_quad_float.hpp
+++ b/include/boost/multiprecision/cpp_quad_float.hpp
@@ -764,7 +764,7 @@ class cpp_quad_fp_backend
 
       std::stringstream ss;
 
-      ss << std::hexfloat;
+      ss << std::hexfloat << std::showpos;
       ss << get<0>(data) << " + " << get<1>(data) << " + " << get<2>(data) << " + " << get<3>(data);
       ss << std::endl;
 


### PR DESCRIPTION
Hello @ckormanyos @cosurgi 

I had made the dangerous mistake of using `1ULL` in `split()` procedure for constexpr-compliant binary shifting (see [this](https://github.com/BoostGSoC21/multiprecision/commit/122d2b644cdf0c36da7d3301d25dae717f0948db#diff-bb9459c4a1f6866e23101b1428b9f6a910b63310156b202b3946d414fcb92071L217)). This would have made the `split()` procedure buggy for floats with more than 128 bits of significand.

This PR is an attempt for rectifying, or at least working around the problem.