### PR TITLE
Up some tolerances cpp_double_double specfun

### DIFF
--- a/include/boost/multiprecision/cpp_double_fp.hpp
+++ b/include/boost/multiprecision/cpp_double_fp.hpp
@@ -1092,10 +1092,18 @@ bool cpp_double_fp_backend<FloatingPointType>::rd_string(const char* pstr)
 {
    // TBD: Do we need-to / want-to throw-catch on invalid string input?
 
-   constexpr auto local_cpp_dec_float_digits10 = static_cast<int>(INT16_C(201));
+   using local_double_fp_type = cpp_double_fp_backend<FloatingPointType>;
+
+   constexpr auto local_cpp_dec_float_digits10 =
+      static_cast<int>
+      (
+         static_cast<float>
+         (
+            static_cast<float>(local_double_fp_type::my_digits) * 0.9F
+         )
+      );
 
    using local_cpp_dec_float_type     = boost::multiprecision::cpp_dec_float<static_cast<unsigned>(local_cpp_dec_float_digits10), std::int32_t, std::allocator<void>>;
-   using local_double_fp_type         = cpp_double_fp_backend<FloatingPointType>;
    using local_cpp_dec_float_exp_type = typename local_cpp_dec_float_type::exponent_type;
 
    local_cpp_dec_float_type f_dec = pstr;

--- a/test/math/log1p_expm1_test.cpp
+++ b/test/math/log1p_expm1_test.cpp
@@ -69,6 +69,15 @@ void expected_results()
        500,                          // Max Peek error
        100);                         // Max mean error
    add_expected_result(
+       ".*",                         // compiler
+       ".*",                         // stdlib
+       ".*",                         // platform
+       ".*cpp_double_double.*",      // test type(s)
+       ".*",                         // test data group
+       ".*",                         // test function
+       30,                           // Max Peek error
+       5);                           // Max mean error
+   add_expected_result(
        ".*", // compiler
        ".*", // stdlib
        ".*", // platform

--- a/test/math/powm1_sqrtp1m1_test.cpp
+++ b/test/math/powm1_sqrtp1m1_test.cpp
@@ -58,6 +58,15 @@ void expected_results()
        300,                          // Max Peek error
        50);                          // Max mean error
    add_expected_result(
+       ".*",                         // compiler
+       ".*",                         // stdlib
+       ".*",                         // platform
+       ".*cpp_double_double.*",      // test type(s)
+       ".*",                         // test data group
+       ".*",                         // test function
+       50,                           // Max Peek error
+       15);                          // Max mean error
+   add_expected_result(
        ".*", // compiler
        ".*", // stdlib
        ".*", // platform

--- a/test/math/test_bessel_y.cpp
+++ b/test/math/test_bessel_y.cpp
@@ -49,6 +49,13 @@ void expected_results()
        ".*(Y[nv]|y).*Random.*", // test data group
        ".*", 70000, 4000);      // test function
    add_expected_result(
+       ".*",                      // compiler
+       ".*",                      // stdlib
+       ".*",                      // platform
+       ".*cpp_double_double.*",   // test type(s)
+       ".*Y[n10].*",              // test data group
+       ".*", 50000, 10000);       // test function
+   add_expected_result(
        ".*",                         // compiler
        ".*",                         // stdlib
        ".*",                         // platform
@@ -62,6 +69,20 @@ void expected_results()
        ".*cpp_bin_float.*", // test type(s)
        ".*Y0.*",            // test data group
        ".*", 40000, 20000); // test function
+   add_expected_result(
+       ".*",                    // compiler
+       ".*",                    // stdlib
+       ".*",                    // platform
+       ".*cpp_double_double.*", // test type(s)
+       ".*Y0.*",                // test data group
+       ".*", 900, 400);         // test function
+   add_expected_result(
+       ".*",                    // compiler
+       ".*",                    // stdlib
+       ".*",                    // platform
+       ".*cpp_double_double.*", // test type(s)
+       ".*Y1.*",                // test data group
+       ".*", 900, 300);         // test function
    add_expected_result(
        ".*",            // compiler
        ".*",            // stdlib

--- a/test/math/test_binomial_coeff.cpp
+++ b/test/math/test_binomial_coeff.cpp
@@ -49,6 +49,13 @@ void expected_results()
        ".*",                        // test data group
        ".*", 150, 100);             // test function
    add_expected_result(
+       ".*",                        // compiler
+       ".*",                        // stdlib
+       ".*",                        // platform
+       ".*cpp_double_double.*",     // test type(s)
+       ".*",                        // test data group
+       ".*", 120, 20);              // test function
+   add_expected_result(
        ".*",           // compiler
        ".*",           // stdlib
        ".*",           // platform


### PR DESCRIPTION
The purpose of this PR is to make `specfun` tests better for `cpp_double_double`.

TODOs:
- Some simple tolerance increases where these are appropriate.
- Find out (if possible) what's up with various repeating Gross errors with NaNs, infinities and zeros.