### PR TITLE
Improve specfun but still some failures 5 files

### DIFF
--- a/include/boost/multiprecision/cpp_df_qf/cpp_df_qf_detail.hpp
+++ b/include/boost/multiprecision/cpp_df_qf/cpp_df_qf_detail.hpp
@@ -39,11 +39,11 @@ inline long double            log_of_constituent(long double            x) { ret
 inline ::boost::float128_type log_of_constituent(::boost::float128_type x) { return ::logq(x); }
 #endif
 
-inline constexpr float                  split(const float)                  { return static_cast<float>      (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<float                 >::digits + 1) / 2))); }
-inline constexpr double                 split(const double)                 { return static_cast<double>     (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<double                >::digits + 1) / 2))); }
-inline constexpr long double            split(const long double)            { return static_cast<long double>(1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<long double           >::digits + 1) / 2))); }
+inline constexpr float        split          (float)                  { return static_cast<float>      (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<float                 >::digits + 1) / 2))); }
+inline constexpr double       split          (double)                 { return static_cast<double>     (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<double                >::digits + 1) / 2))); }
+inline constexpr long double  split          (long double)            { return static_cast<long double>(1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<long double           >::digits + 1) / 2))); }
 #if defined(BOOST_HAS_FLOAT128)
-inline constexpr ::boost::float128_type split(const ::boost::float128_type) { return static_cast<::boost::float128_type>(1) + static_cast<::boost::float128_type>(static_cast<::boost::uint128_type>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<::boost::float128_type>::digits + 1) / 2)); }
+inline constexpr ::boost::float128_type split(::boost::float128_type) { return static_cast<::boost::float128_type>(1) + static_cast<::boost::float128_type>(static_cast<::boost::uint128_type>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<::boost::float128_type>::digits + 1) / 2)); }
 #endif
 
 template <class FloatingPointType>

--- a/include/boost/multiprecision/cpp_df_qf/cpp_df_qf_detail.hpp
+++ b/include/boost/multiprecision/cpp_df_qf/cpp_df_qf_detail.hpp
@@ -39,11 +39,11 @@ inline long double            log_of_constituent(long double            x) { ret
 inline ::boost::float128_type log_of_constituent(::boost::float128_type x) { return ::logq(x); }
 #endif
 
-inline float                  split(const float)                  { return static_cast<float>      (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<float                 >::digits + 1) / 2))); }
-inline double                 split(const double)                 { return static_cast<double>     (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<double                >::digits + 1) / 2))); }
-inline long double            split(const long double)            { return static_cast<long double>(1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<long double           >::digits + 1) / 2))); }
+inline constexpr float                  split(const float)                  { return static_cast<float>      (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<float                 >::digits + 1) / 2))); }
+inline constexpr double                 split(const double)                 { return static_cast<double>     (1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<double                >::digits + 1) / 2))); }
+inline constexpr long double            split(const long double)            { return static_cast<long double>(1U + static_cast<unsigned long long>(static_cast<unsigned long long>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<long double           >::digits + 1) / 2))); }
 #if defined(BOOST_HAS_FLOAT128)
-inline ::boost::float128_type split(const ::boost::float128_type) { return static_cast<::boost::float128_type>(1) + static_cast<::boost::float128_type>(static_cast<::boost::uint128_type>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<::boost::float128_type>::digits + 1) / 2)); }
+inline constexpr ::boost::float128_type split(const ::boost::float128_type) { return static_cast<::boost::float128_type>(1) + static_cast<::boost::float128_type>(static_cast<::boost::uint128_type>(1U) << static_cast<unsigned>((cpp_df_qf_detail::ccmath::numeric_limits<::boost::float128_type>::digits + 1) / 2)); }
 #endif
 
 template <class FloatingPointType>

--- a/include/boost/multiprecision/cpp_double_fp.hpp
+++ b/include/boost/multiprecision/cpp_double_fp.hpp
@@ -249,8 +249,16 @@ class cpp_double_fp_backend
    static constexpr int my_max_digits10   = boost::multiprecision::detail::calc_max_digits10<my_digits>::value;
    static constexpr int my_max_exponent   = cpp_df_qf_detail::ccmath::numeric_limits<float_type>::max_exponent;
    static constexpr int my_min_exponent   = cpp_df_qf_detail::ccmath::numeric_limits<float_type>::min_exponent + cpp_df_qf_detail::ccmath::numeric_limits<float_type>::digits;
-   static constexpr int my_max_exponent10 = boost::multiprecision::detail::calc_digits10<my_max_exponent>::value;
-   static constexpr int my_min_exponent10 = boost::multiprecision::detail::calc_digits10<my_min_exponent>::value;
+   static constexpr int my_max_exponent10 = boost::multiprecision::detail::calc_digits10<static_cast<unsigned>(my_max_exponent)>::value;
+
+   static constexpr int my_min_exponent10 =
+      static_cast<int>
+      (
+         -static_cast<int>
+          (
+             boost::multiprecision::detail::calc_digits10<static_cast<unsigned>(-my_min_exponent)>::value
+          )
+      );
 
    // TBD: Did we justify this static assertion during the GSoC?
    // Does anyone remember what the meaning of the number 77 is?


### PR DESCRIPTION
The purpose of the PR is to further improve the output of the `specfun`tests.

We still do, however, have 5 files failing `specfun`.

Failing functions include:
- test_ibeta_inv_1.cpp (unkonwn, check exponentiation).
- test_ibeta_3.cpp ( maybe, ... also exponential function for large/small arguments).
- test_erf.cpp (most probably exponential function in extreme case).
- test_bessel_k.cpp (one test case out of the range of the backend type).
- test_carlson_2.cpp (many unknown errors, reason completely unknown, but text outputs now more meaningful).

Fahad (@sinandredemption) I'll try to isolate example(s) of each kind of test failure for detailed analysis soon.

Let's see if this thing passes the other parts of CI.
